### PR TITLE
Add recipe: custom ops with applications in AI models

### DIFF
--- a/custom-ops-ai-applications/.gitignore
+++ b/custom-ops-ai-applications/.gitignore
@@ -1,0 +1,8 @@
+# pixi environments
+.pixi
+*.egg-info
+# magic environments
+.magic
+.env
+# build products
+operations.mojopkg

--- a/custom-ops-ai-applications/README.md
+++ b/custom-ops-ai-applications/README.md
@@ -1,0 +1,131 @@
+# Custom Operations: Applications in AI models
+
+In this recipe, we will cover:
+
+* Building a top-K token sampler for GPU and CPU.
+* Implementing FlashAttention-2 as a fused custom operation.
+* Accessing GPU hardware features, like Tensor Cores, from MAX.
+
+We'll walk through two examples that 
+
+* illustrate real-world applications of custom MAX Graph operations in AI
+  models,
+* applies seven optimizations that sequentially improve GPU performance,
+* and demonstrates the performance benefits with benchmarks of each step.
+
+Let's get started.
+
+## Requirements
+
+Please make sure your system meets our
+[system requirements](https://docs.modular.com/max/get-started).
+
+To proceed, ensure you have the `magic` CLI installed:
+
+```bash
+curl -ssL https://magic.modular.com/ | bash
+```
+
+or update it via:
+
+```bash
+magic self-update
+```
+
+### GPU requirements
+
+These examples can all be run on either a CPU or GPU. To run them on a GPU,
+ensure your system meets
+[these GPU requirements](https://docs.modular.com/max/faq/#gpu-requirements):
+
+* Officially supported GPUs: NVIDIA Ampere A-series (A100/A10), or Ada
+  L4-series (L4/L40) data center GPUs. Unofficially, RTX 30XX and 40XX series
+  GPUs have been reported to work well with MAX.
+* NVIDIA GPU driver version 555 or higher. [Installation guide here](https://www.nvidia.com/download/index.aspx).
+
+## Quick start
+
+1. Download the code for this recipe using git:
+
+```bash
+git clone https://github.com/modular/max-recipes.git
+cd max-recipes/custom-ai-applications
+```
+
+2. Run the examples:
+
+```bash
+magic run top_k
+magic run fused_attention
+```
+
+3. Run the benchmarks of the top-K token sampler to sse how much faster it
+runs on GPU:
+
+```bash
+magic run benchmarks
+```
+
+## Optimizing top-K token sampling for GPUs in MAX
+
+AI models in [MAX](https://docs.modular.com/max/intro) are built as
+computational graphs using the
+[MAX Graph API](https://docs.modular.com/max/tutorials/get-started-with-max-graph-in-python).
+MAX contains within it a powerful graph compiler that can take these graphs
+and optimize them for best performance on a wide range of hardware.
+
+Each node in a MAX Graph is defined by an operation that performs a calculation
+on zero or more inputs and produces one or more outputs. These inputs and
+outputs tend to be in the form of tensors, and the operations are usually
+data-parallel calculations that are accelerated on CPUs or GPUs. In MAX,
+these operations are written using [Mojo](https://docs.modular.com/mojo/manual/),
+a Python-family language built for high-performance computation.
+
+Large language models rely on token samplers to improve the quality of the text
+generated from the model, as well as add interesting variability to the output.
+One sampling technique is top-K token sampling, and this example provides both
+CPU and GPU implementations of this algorithm. The GPU implementation
+demonstrates how to accelerate the sampling via hardware features.
+
+The following can be used to run the top-K token sampling demo:
+
+```bash
+magic run top_k
+```
+
+## Implementing a fused operation for FlashAttention-2
+
+Modern Transformer-based language models are constructed around the attention
+mechanism. Optimizing how attention is performed is a key driver in improving
+large language model performance. One such optimization is the
+[FlashAttention-2](https://arxiv.org/abs/2307.08691) layer. In this example,
+you'll see how to implement FlashAttention-2 as a fused operation that runs on
+the GPU in MAX using Mojo.
+
+To run the example, use the following command:
+
+```bash
+magic run fused_attention
+```
+
+## Conclusion
+
+In this recipe, we've demonstrated how to create custom MAX Graph operations
+that perform functions important in modern AI models: top-K token sampling and
+the FlashAttention-2 attention layer. Each provides examples of how complex
+calculations can be constructed using MAX and Mojo and targeted towards
+hardware features in GPUs.
+
+## Next Steps
+
+* Follow [our tutorial for building a custom operation from scratch](https://docs.modular.com/max/tutorials/build-custom-ops).
+
+* Explore MAX's [documentation](https://docs.modular.com/max/) for additional
+  features. The [`gpu`](https://docs.modular.com/mojo/stdlib/gpu/) module has
+  detail on Mojo's GPU programming functions and types, and the documentation
+  on [`@compiler.register`](https://docs.modular.com/max/api/mojo-decorators/compiler-register/)
+  shows how to register custom graph operations.
+
+* Join our [Modular Forum](https://forum.modular.com/) and [Discord community](https://discord.gg/modular) to share your experiences and get support.
+
+We're excited to see what you'll build with MAX! Share your projects and experiences with us using `#ModularAI` on social media.

--- a/custom-ops-ai-applications/benchmarks.mojo
+++ b/custom-ops-ai-applications/benchmarks.mojo
@@ -1,0 +1,135 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from operations.top_k import TopK
+from gpu.host import DeviceContext
+from utils import IndexList
+from max.driver import cpu
+from max.tensor import (
+    ManagedTensorSlice,
+    InputTensor,
+    OutputTensor,
+    StaticTensorSpec,
+)
+from random import rand
+from memory import UnsafePointer
+from runtime.asyncrt import DeviceContextPtr
+from benchmark import ThroughputMeasure, BenchId, BenchMetric, Bench, Bencher
+from bit import log2_floor
+from sys import sizeof, has_nvidia_gpu_accelerator
+from memory import AddressSpace
+
+
+def top_k():
+    alias batch_size = 30_000
+    alias K = 32
+    alias els = batch_size * K
+    alias rank = 2
+    alias shape = IndexList[rank](batch_size, K)
+    alias val_dtype = DType.float32
+    alias idx_dtype = DType.int32
+
+    # Slightly better performance compared to `create_unknown`. Using global
+    # address space doesn't improve perf for GPU.
+    alias val_spec = StaticTensorSpec[val_dtype, rank](
+        shape=(batch_size, K),
+        strides=(K, 1),
+        alignment=sizeof[val_dtype](),
+        address_space=AddressSpace.GENERIC,
+        exclusive=True,
+        in_lambda=None,
+        out_lambda=None,
+    )
+    alias idx_spec = StaticTensorSpec[idx_dtype, rank](
+        shape=(batch_size, K),
+        strides=(K, 1),
+        alignment=sizeof[idx_dtype](),
+        address_space=AddressSpace.GENERIC,
+        exclusive=True,
+        in_lambda=None,
+        out_lambda=None,
+    )
+
+    var in_vals = InputTensor[static_spec=val_spec].rand()
+    var out_vals = OutputTensor[static_spec=val_spec].rand()
+    var out_idxs = OutputTensor[static_spec=idx_spec].rand()
+
+    var cpu_ctx = DeviceContext(api="cpu")
+
+    @parameter
+    @always_inline
+    fn bench_cpu(mut b: Bencher) raises:
+        @parameter
+        @always_inline
+        fn run_bench() raises:
+            TopK.execute[K=K, target="cpu"](
+                out_vals, out_idxs, in_vals, cpu_ctx
+            )
+
+        b.iter[run_bench]()
+
+    var flops = ThroughputMeasure(BenchMetric.flops, els * log2_floor(K))
+    var elements = ThroughputMeasure(BenchMetric.elements, els)
+
+    var b = Bench()
+    b.bench_function[bench_cpu](BenchId("top_k_custom", "cpu"), flops, elements)
+
+    @parameter
+    if has_nvidia_gpu_accelerator():
+        var gpu_ctx = DeviceContext()
+
+        var in_vals_dev_buff = gpu_ctx.enqueue_create_buffer[val_dtype](els)
+        var out_vals_dev_buff = gpu_ctx.enqueue_create_buffer[val_dtype](els)
+        var out_idxs_dev_buff = gpu_ctx.enqueue_create_buffer[idx_dtype](els)
+
+        gpu_ctx.enqueue_copy(in_vals_dev_buff, in_vals.unsafe_ptr())
+
+        var out_vals_dev = OutputTensor[static_spec=val_spec](
+            out_vals_dev_buff.unsafe_ptr(), shape
+        )
+        var out_idxs_dev = OutputTensor[static_spec=idx_spec](
+            out_idxs_dev_buff.unsafe_ptr(), shape
+        )
+        var in_vals_dev = InputTensor[static_spec=val_spec](
+            in_vals_dev_buff.unsafe_ptr(), shape
+        )
+
+        @parameter
+        @always_inline
+        fn bench_gpu(mut b: Bencher) raises:
+            @parameter
+            @always_inline
+            fn kernel_launch(gpu_ctx: DeviceContext) raises:
+                TopK.execute[K=K, target="gpu"](
+                    out_vals_dev, out_idxs_dev, in_vals_dev, gpu_ctx
+                )
+
+            b.iter_custom[kernel_launch](gpu_ctx)
+
+        b.bench_function[bench_gpu](
+            BenchId("top_k_custom", "gpu"), flops, elements
+        )
+        _ = in_vals_dev_buff
+        _ = out_vals_dev_buff
+        _ = out_idxs_dev_buff
+
+    b.config.verbose_metric_names = False
+    print(b)
+
+    _ = in_vals
+    _ = out_vals
+    _ = out_idxs
+
+
+def main():
+    top_k()

--- a/custom-ops-ai-applications/fused_attention.py
+++ b/custom-ops-ai-applications/fused_attention.py
@@ -1,0 +1,68 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import os
+from pathlib import Path
+
+import numpy as np
+from max.driver import CPU, Accelerator, Tensor, accelerator_count
+from max.dtype import DType
+from max.engine.api import InferenceSession
+from max.graph import Graph, TensorType, ops
+
+
+def main():
+    path = Path(__file__).parent / "operations.mojopkg"
+
+    dtype = DType.float32
+    N = 32
+    D = 32
+    BD = 8
+    BN = 16
+    with Graph(
+        "fused_attention",
+        input_types=[
+            TensorType(dtype, shape=[N, D]),
+            TensorType(dtype, shape=[N, D]),
+            TensorType(dtype, shape=[N, D]),
+        ],
+    ) as graph:
+        q, k, v, *_ = graph.inputs
+        results = ops.custom(
+            name="fused_attention_custom",
+            parameters={"N": N, "D": D, "BD": BD, "BN": BN},
+            values=[q, k, v],
+            out_types=[TensorType(dtype, shape=[N, D])],
+        )
+        graph.output(*results)
+
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+
+    # Set up an inference session for running the graph.
+    session = InferenceSession(devices=[device], custom_extensions=path)
+
+    # Compile the graph.
+    model = session.load(graph)
+
+    np.random.seed(123)
+    Q = Tensor.from_numpy(np.random.randn(N, D).astype("f")).to(device)
+    K = Tensor.from_numpy(np.random.randn(N, D).astype("f")).to(device)
+    V = Tensor.from_numpy(np.random.randn(N, D).astype("f")).to(device)
+
+    output = model.execute(Q, K, V)
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-ops-ai-applications/metadata.yaml
+++ b/custom-ops-ai-applications/metadata.yaml
@@ -1,0 +1,18 @@
+version: 1.0
+long_title: "Custom Operations: Applications in AI Models"
+short_title: "Custom Operations: Applications in AI Models"
+author: "Brad Larson"
+author_image: "author/bradlarson.jpg"
+author_url: "https://www.linkedin.com/in/brad-larson-3549a5291/"
+github_repo: "https://github.com/modular/max-recipes/tree/main/custom-ops-ai-applications"
+date: "23-02-2025"
+difficulty: "advanced"
+tags:
+  - max-graph
+  - gpu-programming
+  - mojo
+
+tasks:
+  - magic run top_k
+  - magic run fused_attention
+  - magic run benchmarks

--- a/custom-ops-ai-applications/operations/__init__.mojo
+++ b/custom-ops-ai-applications/operations/__init__.mojo
@@ -1,0 +1,12 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #

--- a/custom-ops-ai-applications/operations/fused_attention.mojo
+++ b/custom-ops-ai-applications/operations/fused_attention.mojo
@@ -1,0 +1,361 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""
+The code below computes the attention score for a tile of size BN x BD.
+It follows the exact arithmetic as described in the FlashAttention-2 paper
+(https://arxiv.org/pdf/2307.08691). The variable names in this program
+reflect the variable names in the algorithms from the paper.
+
+Here, the following tensors are Q for the query,
+K for the key, V for the value, and O for the output.
+
+       Q            K               V
+  +----D----+  +----D----+   +--+--BD--+---+
+  |         |  |.........|   |  |......|   |
+  |         |  |.........|   |  |......|   |
+  +---------+  |.........|   |  |......|   |
+  |.........|  |.........|   |  |......|   |
+  BN........|  N.........|   N  |......|   |
+  |.........|  |.........|   |  |......|   |
+  +---------+  |.........|   |  |......|   |
+  |         |  |.........|   |  |......|   |
+  |         |  |.........|   |  |......|   |
+  |         |  |.........|   |  |......|   |
+  +---------+  +---------+   +--+------+---+
+
+The main trick is in the softmax computation.
+As the paper says, S and P are intermediate values.
+
+Let S = Q * K^T  ∈ R^{N, D}
+    P = Softmax(S) ∈ R^{N, D}
+The attention score is O = P * V ∈ R^{N, D}.
+
+One way to think about this is to consider what happens if we
+split the dimensions N in  K, and Q into two tiles: K_1 and K_2, V_1 and V_2.
+Then we can incrementally compute the output as follows:
+  S_1 = Q * K_1, S_2 = Q * K_2
+  O_i = O_{i-1} * renormalization_factor + softmax(S_i) * V_i
+
+This allows for the incremental computation of softmax(S_i) * V_i,
+leading to the final output.
+"""
+
+
+from algorithm import parallelize_over_rows
+from compiler import register
+from utils.index import IndexList
+from layout import Layout, LayoutTensor, RuntimeLayout, RuntimeTuple
+from layout.tensor_core import TensorCore
+from layout.math import exp, sum, max
+from gpu.host import DeviceContext
+from gpu.id import block_idx, thread_idx
+from gpu.sync import barrier
+from gpu.memory import AddressSpace
+from runtime.asyncrt import DeviceContextPtr
+from utils import Index
+
+from tensor import ManagedTensorSlice
+
+
+@register("fused_attention_custom", num_dps_outputs=1)
+struct FusedAttention:
+    """Registers the `fused_attention_custom` op, allowing python to use it from the `max`
+    package.
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        rank: Int,
+        //,  # Forces the previous two params to be inferred from the args
+        N: Int,  # Input length
+        D: Int,  # Head dimension
+        BN: Int,  # Dimension of blocks to split Q into
+        BD: Int,  # Dimension of blocks to split K, V into
+        target: StringLiteral,  # "cpu" or "gpu"
+    ](
+        output: ManagedTensorSlice[type=dtype, rank=rank],
+        key: ManagedTensorSlice[type=dtype, rank=rank],
+        query: ManagedTensorSlice[type=dtype, rank=rank],
+        value: ManagedTensorSlice[type=dtype, rank=rank],
+        ctx: DeviceContextPtr,
+    ) raises:
+        constrained[rank == 2, "rank must be 2"]()
+
+        # Key tensor
+        K = key.to_layout_tensor()
+        # Query tensor
+        Q = query.to_layout_tensor()
+        # Value tensor
+        V = value.to_layout_tensor()
+        # Attention output tensor
+        O = output.to_layout_tensor()
+
+        @parameter
+        if target == "cpu":
+            print("Running on CPU")
+            fused_attention_cpu[BN, BD](K, Q, V, O)
+        else:
+            dev_ctx = ctx.get_device_context()
+            print("Running on GPU")
+            fused_attention_gpu[BN, BD](dev_ctx, K, Q, V, O)
+
+
+@always_inline
+fn matmul_b_transpose(
+    lhs: LayoutTensor,
+    rhs: LayoutTensor,
+    out res: LayoutTensor[
+        lhs.dtype, Layout.row_major(lhs.shape[0](), rhs.shape[0]())
+    ],
+):
+    res = __type_of(res).stack_allocation()
+
+    @parameter
+    for m in range(lhs.shape[0]()):
+
+        @parameter
+        for n in range(rhs.shape[0]()):
+            res[m, n] = 0.0
+
+            @parameter
+            for k in range(lhs.shape[1]()):
+                res[m, n] += rebind[res.element_type](
+                    lhs[m, k].cast[res.dtype]()
+                ) * rebind[res.element_type](rhs[n, k].cast[res.dtype]())
+
+
+"""
+The bulk of the code below implements what the papers calls
+an "online softmax", which is local to each block.
+The algorithm is described as:
+
+$$$
+m_1 = rowmax(S_1)
+l_1 = rowsum(e^(S_1-m_1))
+P_1 = diag(l_1)^-1 * e^(S_1-m_1)
+O_1 = P_1*V_1 = diag(l_1)^-1 * e^(S_1-m_1) * V_1
+m_2 = max(m_1, rowmax(S_2)) = m
+l_2 = e^(m_1-m_2) * l_1 _ rowsum(e^(S_2-m_2))
+    = rowsum(e^(S_1-m)) + rowsum(e^(S_2-m)) = ls
+P_2 = diag(l_2)^-1 * e^(S_2-m_2)
+O_2 = diag(l_1/l_2)^-1 * O_1 + (P_2 * V_2)
+    = diag(l_2)^-1 * e^(S_2-m) * V
+$$$
+"""
+
+
+@always_inline
+fn fused_attention_cpu[
+    BN: Int, BD: Int
+](Q: LayoutTensor, K: LayoutTensor, V: LayoutTensor, mut O: LayoutTensor):
+    alias N = K.shape[0]()
+    alias D = K.shape[1]()
+
+    @parameter
+    for tile_n in range(N // BN):
+        Q_tile = Q.tile[BN, D](tile_n, 0)
+
+        @parameter
+        for tile_d in range(D // BD):
+            m_1 = (
+                LayoutTensor[Q_tile.dtype, Layout(BN, 1)]
+                .stack_allocation()
+                .fill(Scalar[Q_tile.dtype].MIN)
+            )
+
+            l_1 = (
+                LayoutTensor[Q_tile.dtype, Layout(BN, 1)]
+                .stack_allocation()
+                .fill(0)
+            )
+
+            O_i = (
+                LayoutTensor[Q_tile.dtype, Layout.row_major(BN, BD)]
+                .stack_allocation()
+                .fill(0)
+            )
+
+            @parameter
+            for tile_n_idx in range(N // BN):
+                K_tile = K.tile[BN, D](tile_n_idx, 0)
+                V_tile = V.tile[BN, BD](tile_n_idx, tile_d)
+
+                S = matmul_b_transpose(Q_tile, K_tile)
+                m_2 = max(m_1, rebind[__type_of(m_1)](max[axis=1](S)))
+                l_2 = exp(m_1 - m_2) * l_1 + sum[axis=1](exp(S - m_2))
+
+                P = exp(S - m_2) / l_2
+                O_i = O_i * (l_1 / l_2) * exp(m_1 - m_2) + matmul["cpu"](
+                    P, V_tile
+                )
+                m_1 = m_2
+                l_1 = rebind[__type_of(l_1)](l_2)
+
+            O.tile[BN, BD](tile_n, tile_d).copy_from(O_i)
+
+
+@always_inline
+fn matmul[
+    target: StringLiteral,
+    transpose_b: Bool = False,
+](
+    lhs: LayoutTensor,
+    rhs: LayoutTensor,
+    out res: LayoutTensor[
+        lhs.dtype,
+        Layout.row_major(lhs.shape[0](), rhs.shape[0]()),
+        address_space = lhs.address_space,
+        element_layout = lhs.element_layout,
+        layout_bitwidth = lhs.layout_bitwidth,
+    ],
+):
+    res = __type_of(res).stack_allocation()
+
+    @parameter
+    if target == "cpu":
+
+        @parameter
+        for m in range(lhs.shape[0]()):
+
+            @parameter
+            for n in range(rhs.shape[1]()):
+                res[m, n] = 0.0
+
+                @parameter
+                for k in range(lhs.shape[1]()):
+                    res[m, n] += rebind[res.element_type](
+                        lhs[m, k].cast[res.dtype]()
+                    ) * rebind[res.element_type](rhs[k, n].cast[res.dtype]())
+    else:
+        alias M = res.shape[0]()
+        alias N = res.shape[1]()
+        alias K = lhs.shape[1]()
+
+        out_sram = LayoutTensor[
+            res.dtype,
+            Layout.row_major(M, N),
+            address_space = AddressSpace.SHARED,
+        ].stack_allocation()
+
+        alias BK = 8
+
+        constrained[K % 8 == 0, "K needs to be a multiple of 8"]()
+
+        mma_b_t = TensorCore[
+            lhs.dtype, res.dtype, Index(M, N, BK), transpose_b
+        ]()
+
+        c_reg = mma_b_t.c_reg_tile_type.stack_allocation().fill(0)
+
+        @parameter
+        for k_i in range(K // BK):
+            a_reg = mma_b_t.load_a(lhs.tile[M, BK](0, k_i))
+
+            b_reg = mma_b_t.load_b(rhs.tile[BK, N](k_i, 0))
+
+            @parameter
+            if transpose_b:
+                b_reg = rebind[__type_of(b_reg)](
+                    mma_b_t.load_b(rhs.tile[N, BK](0, k_i))
+                )
+
+            d_reg = mma_b_t.mma_op(a_reg, b_reg, c_reg)
+            c_reg.copy_from(d_reg)
+        mma_b_t.store_d(out_sram, c_reg)
+
+        barrier()
+        res.copy_from(out_sram)
+
+
+fn fused_attention_kenel[
+    q_dtype: DType,
+    q_layout: Layout,
+    k_dtype: DType,
+    k_layout: Layout,
+    v_dtype: DType,
+    v_layout: Layout,
+    o_dtype: DType,
+    o_layout: Layout,
+    BN: Int,
+    BD: Int,
+](
+    Q: LayoutTensor[q_dtype, q_layout],
+    K: LayoutTensor[k_dtype, k_layout],
+    V: LayoutTensor[v_dtype, v_layout],
+    O: LayoutTensor[o_dtype, o_layout],
+):
+    alias N = Q.shape[0]()
+    alias D = Q.shape[1]()
+
+    Q_tile = Q.tile[BN, D](block_idx.y, 0)
+
+    m_1 = (
+        LayoutTensor[q_dtype, Layout(BN, 1)]
+        .stack_allocation()
+        .fill(Scalar[q_dtype].MIN)
+    )
+    l_1 = LayoutTensor[q_dtype, Layout(BN, 1)].stack_allocation().fill(0)
+    O_i = (
+        LayoutTensor[q_dtype, Layout.row_major(BN, BD)]
+        .stack_allocation()
+        .fill(0)
+    )
+
+    alias BN_1 = 8
+
+    @parameter
+    for tile_n_idx in range(N // BN_1):
+        K_tile = K.tile[BN_1, D](tile_n_idx, 0)
+        V_tile = V.tile[BN_1, BD](tile_n_idx, block_idx.x)
+        S = matmul["gpu", transpose_b=True](Q_tile, K_tile)
+        m_2 = max(m_1, rebind[__type_of(m_1)](max[axis=1](S)))
+        l_2 = exp(m_1 - m_2) * l_1 + sum[axis=1](exp(S - m_2))
+        P = exp(S - m_2) / l_2
+        O_i = O_i * (l_1 / l_2) * exp(m_1 - m_2) + matmul["gpu"](P, V_tile)
+        m_1 = m_2
+        l_1 = rebind[__type_of(l_1)](l_2)
+    O.tile[BN, BD](block_idx.y, block_idx.x).copy_from(O_i)
+
+
+def fused_attention_gpu[
+    BN: Int,
+    BD: Int,
+](
+    ctx: DeviceContext,
+    Q: LayoutTensor,
+    K: LayoutTensor,
+    V: LayoutTensor,
+    mut O: LayoutTensor,
+):
+    alias kernel_func = fused_attention_kenel[
+        Q.dtype,
+        Q.layout,
+        K.dtype,
+        K.layout,
+        V.dtype,
+        V.layout,
+        O.dtype,
+        O.layout,
+        BN,
+        BD,
+    ]
+    ctx.enqueue_function[kernel_func](
+        Q,
+        K,
+        V,
+        O,
+        grid_dim=(Q.shape[1]() // BD, Q.shape[0]() // BN),
+        block_dim=(32),
+    )

--- a/custom-ops-ai-applications/operations/top_k.mojo
+++ b/custom-ops-ai-applications/operations/top_k.mojo
@@ -1,0 +1,160 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from math import iota
+from sys import alignof, sizeof, num_physical_cores
+from algorithm import parallelize_over_rows
+from bit import log2_floor
+from compiler import register
+from gpu import WARP_SIZE, barrier, warp
+from gpu.id import block_dim, block_idx, thread_idx
+from gpu.memory import AddressSpace, external_memory
+from max.tensor import ManagedTensorSlice
+from memory import Span
+from runtime.asyncrt import DeviceContextPtr
+from utils.index import IndexList
+from utils.numerics import min_or_neg_inf
+
+
+@value
+@register_passable("trivial")
+struct TopKElement[T: DType]:
+    """Stores the value with it's index."""
+
+    var idx: Int32
+    var val: Scalar[T]
+
+    fn __gt__(self, rhs: Self) -> Bool:
+        return self.val > rhs.val
+
+
+@register("top_k_custom", num_dps_outputs=2)
+struct TopK:
+    """Registers the `top_k_custom` op, allowing python to use it from the `max`
+    package. This is a simplified version without bottom_k and sorting options,
+    or fused sampling. The purpose is to demonstrate concisely how you can
+    implement your own custom ops in Mojo that can be called from Python. MAX
+    has the "mo.top_k" op which is feature complete.
+    """
+
+    @staticmethod
+    fn execute[
+        type: DType,
+        rank: Int,
+        //,  # Forces the previous two params to be inferred from the args
+        K: Int,
+        target: StringLiteral,
+    ](
+        out_vals: ManagedTensorSlice[type=type, rank=rank],
+        out_idxs: ManagedTensorSlice[type = DType.int32, rank=rank],
+        in_vals: ManagedTensorSlice[type=type, rank=rank],
+        ctx: DeviceContextPtr,
+    ) raises:
+        constrained[rank == 2, "rank must be 2"]()
+        constrained[
+            not (target == "gpu" and K > WARP_SIZE),
+            "K can't be larger than warp size",
+        ]()
+
+        var shape = in_vals.shape()
+        var batch_size = shape[0]
+        var dev_ctx = ctx.get_device_context()
+
+        @parameter
+        fn top_k_gpu[
+            K: Int,
+        ](
+            out_vals: __type_of(out_vals),
+            out_idxs: __type_of(out_idxs),
+            in_vals: __type_of(in_vals),
+        ):
+            var bid = block_idx.x
+            var tid = thread_idx.x
+
+            # Get a pointer to shared memory for the indices and values
+            var top_k_sram = external_memory[
+                TopKElement[type],
+                address_space = AddressSpace.SHARED,
+                alignment = alignof[TopKElement[type]](),
+            ]()
+
+            # Threads put their corresponding index and value into shared memory
+            top_k_sram[tid] = TopKElement(tid, in_vals[bid, tid])
+            # Finish packing the values across threads in this block
+            barrier()
+
+            @parameter
+            for i in range(K):
+                var reduced = top_k_sram[tid]
+                alias limit = log2_floor(WARP_SIZE)
+
+                # TODO(KERN-1544): `gpu.shuffle.warp_max` support index/value
+                @parameter
+                for j in reversed(range(limit)):
+                    alias offset = 1 << j
+                    # Parallel reduction using warp shuffle. Each thread gets a
+                    # value from a thread 'offset' positions higher, keeping the
+                    # larger value.
+                    var shuffled = TopKElement(
+                        warp.shuffle_down(reduced.idx, offset),
+                        warp.shuffle_down(reduced.val, offset),
+                    )
+                    reduced = max(reduced, shuffled)
+
+                # Wait for all threads to finish reducing their values
+                barrier()
+
+                # Thread 0 now has the reduced max value for this index
+                if tid == 0:
+                    # Store the reduced top_k index and value in global memory
+                    out_vals[bid, i] = reduced.val
+                    out_idxs[bid, i] = reduced.idx
+
+                    # Remove found maximum from consideration in the next iter
+                    var index = reduced.idx % block_dim.x
+                    top_k_sram[index].val = min_or_neg_inf[type]()
+
+        @parameter
+        if target == "gpu":
+            dev_ctx.enqueue_function[top_k_gpu[K]](
+                out_vals,
+                out_idxs,
+                in_vals,
+                grid_dim=batch_size,  # One block per batch
+                block_dim=K,  # One thread per K
+                shared_mem_bytes=K * sizeof[TopKElement[type]](),
+            )
+        else:
+
+            @parameter
+            fn top_k_cpu(start_idx: Int, end_idx: Int):
+                for row_idx in range(start_idx, end_idx):
+                    var offset = (row_idx * K)
+                    iota(out_idxs.unsafe_ptr() + offset, K)
+
+                    @parameter
+                    fn val_greater_than(lhs: Int32, rhs: Int32) -> Bool:
+                        return (
+                            in_vals[row_idx, Int(lhs)]
+                            > in_vals[row_idx, Int(rhs)]
+                        )
+
+                    sort[val_greater_than](
+                        Span(out_idxs.unsafe_ptr() + offset, K)
+                    )
+
+                    for i in range(K):
+                        var sorted_idx = Int(out_idxs[row_idx, i])
+                        out_vals[row_idx, i] = in_vals[row_idx, sorted_idx]
+
+            parallelize_over_rows[top_k_cpu](shape, axis=1, grain_size=1)

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+authors = [{ name = "Modular Inc", email = "hello@modular.com" }]
+description = "Custom Operations: Applications in AI Models"
+name = "custom-ops-ai-applications"
+requires-python = ">= 3.9,<3.13"
+version = "0.1.0"
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.pixi.project]
+channels = [
+    "conda-forge",
+    "https://conda.modular.com/max-nightly",
+    "https://conda.modular.com/max",
+    "https://repo.prefix.dev/modular-community",
+]
+platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
+
+[tool.pixi.tasks]
+package = "mojo package operations/ -o operations.mojopkg"
+top_k = { cmd = "python top_k.py", depends-on = ["package"] }
+fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] }
+benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
+
+[tool.pixi.dependencies]
+max = ">=25.2.0.dev2025022205"

--- a/custom-ops-ai-applications/top_k.py
+++ b/custom-ops-ai-applications/top_k.py
@@ -1,0 +1,194 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+import argparse
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import DefaultDict
+
+import numpy as np
+from max.driver import CPU, Accelerator, Tensor, accelerator_count
+from max.dtype import DType
+from max.engine.api import InferenceSession
+from max.graph import Graph, TensorType, ops
+from numpy.typing import NDArray
+
+INPUT_TEXT = """
+The quick rabbit runs past the brown fox
+The quick rabbit jumps over the brown dog
+The quick dog chases past the lazy fox
+The quick dog runs through the tall trees
+The quick brown fox jumps over the lazy dog
+The brown dog sleeps under the shady tree
+The brown rabbit hops under the tall tree
+The brown fox runs through the forest trees
+The brown fox watches the sleeping rabbit
+The lazy fox watches over the sleeping dog
+The lazy dog watches the quick rabbit
+The shady tree shelters the brown rabbit
+The shady fox sleeps under the old tree
+The sleeping fox rests beside the shady tree
+The lazy rabbit rests beside the brown fox
+"""
+
+
+class NextWordFrequency:
+    def __init__(self, text):
+        # nested `DefaultDict` to create the keys when first indexed
+        # Structure looks like: {"word": {"next_word": count}}
+        self.word_frequencies: DefaultDict[str, DefaultDict[str, int]] = (
+            defaultdict(lambda: defaultdict(int))
+        )
+
+        # Track the largest amount of next words to pad the tensor
+        self.max_next_words = 0
+
+        # Build word frequencies
+        words = text.lower().split()
+        for i in range(len(words) - 1):
+            current_word = words[i]
+            next_word = words[i + 1]
+            self.word_frequencies[current_word][next_word] += 1
+            self.max_next_words = max(
+                self.max_next_words, len(self.word_frequencies[current_word])
+            )
+
+    def next_word_probabilities(self, words) -> NDArray[np.float32]:
+        if not words:
+            return np.empty(0, dtype=np.float32)
+
+        # List to store the probability distributions for each word
+        prob_distributions = []
+
+        for word in words:
+            if word not in self.word_frequencies:
+                raise ValueError(
+                    f"Error: cannot predict word after '{word}', not found in input text"
+                )
+
+        for word in words:
+            frequencies = self.word_frequencies[word]
+            freq_list = np.array(list(frequencies.values()), dtype=np.float32)
+
+            # Avoid division by zero
+            total = freq_list.sum()
+            if total > 0:
+                freq_list /= total
+
+            # Pad to largest length of next words
+            padded_dist = np.pad(
+                freq_list,
+                (0, self.max_next_words - len(freq_list)),
+                mode="constant",
+                constant_values=0,
+            )
+            prob_distributions.append(padded_dist)
+
+        return np.stack(prob_distributions, axis=0)
+
+    def __getitem__(self, idx):
+        return self.word_frequencies[idx]
+
+
+# Example usage
+def main():
+    parser = argparse.ArgumentParser(
+        description="Top-K sampling with custom ops"
+    )
+    parser.add_argument(
+        "--cpu",
+        action="store_true",
+        help="Run on CPU even if there is a GPU available.",
+    )
+    args = parser.parse_args()
+
+    # Get the path to our compiled custom ops
+    path = Path(__file__).parent / "operations.mojopkg"
+
+    # Initialize the next word frequency for each unique word
+    frequencies = NextWordFrequency(INPUT_TEXT)
+    word_predictions = ["the", "quick", "brown"]
+
+    # Get probabilities of next word for each word in the `word_predictions` list
+    probabilities = frequencies.next_word_probabilities(word_predictions)
+
+    batch_size = len(probabilities)
+    K = frequencies.max_next_words
+
+    # Configure our simple one-operation graph.
+    with Graph(
+        "top_k_sampler",
+        # The dtype and shape of the probabilities being passed in
+        input_types=[TensorType(DType.float32, shape=[batch_size, K])],
+    ) as graph:
+        # Take the probabilities as a single input to the graph.
+        probs, *_ = graph.inputs
+
+        results = ops.custom(
+            # This is the custom op name defined in `kernels/top_k.mojo`.
+            name="top_k_custom",
+            # Passes `K` as a compile-time Mojo `Int`.
+            parameters={"K": K},
+            # Passes the probabilities as a single input to the graph.
+            values=[probs],
+            out_types=[
+                # The output values dtype and shape
+                TensorType(probs.tensor.dtype, probs.tensor.shape),
+                # The output indices dtype and shape
+                TensorType(DType.int32, probs.tensor.shape),
+            ],
+        )
+        graph.output(*results)
+
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if args.cpu or accelerator_count() == 0 else Accelerator()
+
+    # Set up an inference session for running the graph.
+    session = InferenceSession(devices=[device], custom_extensions=path)
+
+    # Compile the graph.
+    model = session.load(graph)
+
+    # Create a driver tensor from the next word probabilities
+    input_tensor = Tensor.from_numpy(probabilities).to(device)
+
+    print(f"Sampling top k: {K} for batch size: {batch_size}")
+
+    values, indices = model.execute(input_tensor)
+
+    # Copy values and indices back to the CPU to be read.
+    assert isinstance(values, Tensor)
+    values = values.to(CPU())
+    np_values = values.to_numpy()
+
+    assert isinstance(indices, Tensor)
+    indices = indices.to(CPU())
+    np_indices = indices.to_numpy()
+
+    for i in range(batch_size):
+        print(f"\nPredicted word after `{word_predictions[i]}`")
+        print("-------------------------------")
+        print("| word         | confidence   |")
+        print("-------------------------------")
+        keys = list(frequencies.word_frequencies[word_predictions[i]].keys())
+
+        for j in range(len(np_indices[i])):
+            # If it's a padded index/value, break out of the loop
+            if j > len(keys) - 1:
+                break
+            print(f"| {keys[np_indices[i][j]]:<13}| {np_values[i][j]:<13.8}|")
+        print("-------------------------------")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a recipe for the more advanced custom ops examples: top-K token sampling and a fused attention layer.

Marking this as a draft for now, because significant additions need to be made to the README to fill in relevant information about the two operations and what people should learn as they examine the code. The rest of the scaffolding is there, as well as all example code and what's needed to run them.