### PR TITLE
Update custom ops and GPU function recipes for the latest MAX nightlies

### DIFF
--- a/custom-ops-ai-applications/operations/top_k.mojo
+++ b/custom-ops-ai-applications/operations/top_k.mojo
@@ -19,7 +19,7 @@ from compiler import register
 from gpu import WARP_SIZE, barrier, warp
 from gpu.id import block_dim, block_idx, thread_idx
 from gpu.memory import AddressSpace, external_memory
-from max.tensor import ManagedTensorSlice
+from max.tensor import OutputTensor, InputTensor
 from memory import Span
 from runtime.asyncrt import DeviceContextPtr
 from utils.index import IndexList
@@ -38,7 +38,7 @@ struct TopKElement[T: DType]:
         return self.val > rhs.val
 
 
-@register("top_k_custom", num_dps_outputs=2)
+@register("top_k_custom")
 struct TopK:
     """Registers the `top_k_custom` op, allowing python to use it from the `max`
     package. This is a simplified version without bottom_k and sorting options,
@@ -55,9 +55,9 @@ struct TopK:
         K: Int,
         target: StringLiteral,
     ](
-        out_vals: ManagedTensorSlice[type=type, rank=rank],
-        out_idxs: ManagedTensorSlice[type = DType.int32, rank=rank],
-        in_vals: ManagedTensorSlice[type=type, rank=rank],
+        out_vals: OutputTensor[type=type, rank=rank],
+        out_idxs: OutputTensor[type = DType.int32, rank=rank],
+        in_vals: InputTensor[type=type, rank=rank],
         ctx: DeviceContextPtr,
     ) raises:
         constrained[rank == 2, "rank must be 2"]()

--- a/custom-ops-ai-applications/top_k.py
+++ b/custom-ops-ai-applications/top_k.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 import argparse
-import os
 from collections import defaultdict
 from pathlib import Path
 from typing import DefaultDict

--- a/custom-ops-introduction/README.md
+++ b/custom-ops-introduction/README.md
@@ -122,8 +122,8 @@ struct AddOne:
     fn execute[
         target: StringLiteral,
     ](
-        out: ManagedTensorSlice,
-        x: ManagedTensorSlice[type = out.type, rank = out.rank],
+        out: OutputTensor,
+        x: InputTensor[type = out.type, rank = out.rank],
         ctx: DeviceContextPtr,
     ):
         @parameter

--- a/custom-ops-introduction/operations/add_one.mojo
+++ b/custom-ops-introduction/operations/add_one.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 import compiler
-from max.tensor import ManagedTensorSlice, foreach
+from tensor import OutputTensor, InputTensor, foreach
 from runtime.asyncrt import DeviceContextPtr
 
 from utils.index import IndexList
@@ -26,12 +26,12 @@ struct AddOne:
         target: StringLiteral,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
-        out: ManagedTensorSlice,
+        out: OutputTensor,
         # starting here are the list of inputs
-        x: ManagedTensorSlice[type = out.type, rank = out.rank],
+        x: InputTensor[type = out.type, rank = out.rank],
         # the context is needed for some GPU calls
         ctx: DeviceContextPtr,
-    ):
+    ) raises:
         @parameter
         @always_inline
         fn elementwise_add_one[

--- a/custom-ops-introduction/operations/mandelbrot.mojo
+++ b/custom-ops-introduction/operations/mandelbrot.mojo
@@ -15,7 +15,7 @@
 import compiler
 from complex import ComplexSIMD
 from math import iota
-from max.tensor import ManagedTensorSlice, foreach
+from tensor import OutputTensor, InputTensor, foreach
 from runtime.asyncrt import DeviceContextPtr
 from utils.index import IndexList
 
@@ -31,7 +31,7 @@ struct Mandelbrot:
         target: StringLiteral,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
-        out: ManagedTensorSlice,
+        out: OutputTensor,
         # starting here are the list of inputs
         min_x: Float32,
         min_y: Float32,
@@ -40,7 +40,7 @@ struct Mandelbrot:
         max_iterations: Int32,
         # the context is needed for some GPU calls
         ctx: DeviceContextPtr,
-    ):
+    ) raises:
         @parameter
         @always_inline
         fn elementwise_mandelbrot[

--- a/custom-ops-introduction/operations/vector_addition.mojo
+++ b/custom-ops-introduction/operations/vector_addition.mojo
@@ -17,15 +17,15 @@ import compiler
 from gpu import block_dim, block_idx, thread_idx
 from gpu.host import DeviceContext
 from runtime.asyncrt import DeviceContextPtr
-from tensor import ManagedTensorSlice, foreach
+from tensor import OutputTensor, InputTensor, foreach
 
 from utils.index import IndexList
 
 
 fn vector_addition_cpu(
-    out: ManagedTensorSlice,
-    lhs: ManagedTensorSlice[type = out.type, rank = out.rank],
-    rhs: ManagedTensorSlice[type = out.type, rank = out.rank],
+    out: OutputTensor,
+    lhs: InputTensor[type = out.type, rank = out.rank],
+    rhs: InputTensor[type = out.type, rank = out.rank],
     ctx: DeviceContextPtr,
 ):
     # Warning: This is an extremely inefficient implementation! It's merely an
@@ -37,9 +37,9 @@ fn vector_addition_cpu(
 
 
 fn vector_addition_gpu(
-    out: ManagedTensorSlice,
-    lhs: ManagedTensorSlice[type = out.type, rank = out.rank],
-    rhs: ManagedTensorSlice[type = out.type, rank = out.rank],
+    out: OutputTensor,
+    lhs: InputTensor[type = out.type, rank = out.rank],
+    rhs: InputTensor[type = out.type, rank = out.rank],
     ctx: DeviceContextPtr,
 ) raises:
     # Note: The following has not been tuned for any GPU hardware, and is an
@@ -75,10 +75,10 @@ struct VectorAddition:
         target: StringLiteral,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
-        out: ManagedTensorSlice[rank=1],
+        out: OutputTensor[rank=1],
         # starting here are the list of inputs
-        lhs: ManagedTensorSlice[type = out.type, rank = out.rank],
-        rhs: ManagedTensorSlice[type = out.type, rank = out.rank],
+        lhs: InputTensor[type = out.type, rank = out.rank],
+        rhs: InputTensor[type = out.type, rank = out.rank],
         # the context is needed for some GPU calls
         ctx: DeviceContextPtr,
     ) raises:

--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -28,7 +28,7 @@ from math import ceildiv
 from memory import UnsafePointer
 from runtime.asyncrt import DeviceContextPtr
 from sys.info import simdwidthof
-from tensor import ManagedTensorSlice, foreach
+from tensor import OutputTensor, InputTensor
 from utils.index import Index
 
 # ===-----------------------------------------------------------------------===#
@@ -37,9 +37,9 @@ from utils.index import Index
 
 
 fn naive_matrix_multiplication_cpu(
-    out: ManagedTensorSlice,
-    a: ManagedTensorSlice[type = out.type, rank = out.rank],
-    b: ManagedTensorSlice[type = out.type, rank = out.rank],
+    out: OutputTensor,
+    a: InputTensor[type = out.type, rank = out.rank],
+    b: InputTensor[type = out.type, rank = out.rank],
 ):
     """A naive matrix multiplication used as a fallback on CPU hardware."""
     var M = a.shape()[0]
@@ -782,10 +782,10 @@ struct MatrixMultiplication[algorithm: StringLiteral]:
         target: StringLiteral,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
-        out: ManagedTensorSlice[rank=2],
+        out: OutputTensor[rank=2],
         # starting here are the list of inputs
-        a: ManagedTensorSlice[type = out.type, rank = out.rank],
-        b: ManagedTensorSlice[type = out.type, rank = out.rank],
+        a: InputTensor[type = out.type, rank = out.rank],
+        b: InputTensor[type = out.type, rank = out.rank],
         # the context is needed for some GPU calls
         ctx: DeviceContextPtr,
     ) raises:

--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -104,9 +104,9 @@ threads past the end of the vector.
 ```mojo
 fn vector_addition(
     length: Int,
-    lhs: TensorType,
-    rhs: TensorType,
-    out: TensorType,
+    lhs: LayoutTensor[float_dtype],
+    rhs: LayoutTensor[float_dtype],
+    out: LayoutTensor[float_dtype],
 ):
     tid = block_dim.x * block_idx.x + thread_idx.x
     if tid < length:
@@ -171,9 +171,9 @@ var num_blocks = ceildiv(VECTOR_WIDTH, BLOCK_SIZE)
 gpu_function(
     gpu_device,
     VECTOR_WIDTH,
-    lhs_tensor.unsafe_slice(),
-    rhs_tensor.unsafe_slice(),
-    out_tensor.unsafe_slice(),
+    lhs_tensor.to_layout_tensor(),
+    rhs_tensor.to_layout_tensor(),
+    out_tensor.to_layout_tensor(),
     grid_dim=Dim(num_blocks),
     block_dim=Dim(BLOCK_SIZE),
 )
@@ -218,8 +218,8 @@ And this is the per-thread function that expresses this to be run on the GPU:
 fn color_to_grayscale_conversion(
     width: Int,
     height: Int,
-    image: TensorType,
-    out: TensorType,
+    image: LayoutTensor[channel_dtype],
+    out: LayoutTensor[channel_dtype],
 ):
     row = block_dim.y * block_idx.y + thread_idx.y
     col = block_dim.x * block_idx.x + thread_idx.x
@@ -247,8 +247,8 @@ gpu_function(
     gpu_device,
     IMAGE_WIDTH,
     IMAGE_HEIGHT,
-    rgb_tensor.unsafe_slice(),
-    gray_tensor.unsafe_slice(),
+    rgb_tensor.to_layout_tensor(),
+    gray_tensor.to_layout_tensor(),
     grid_dim=Dim(num_col_blocks, num_row_blocks),
     block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
 )
@@ -275,9 +275,9 @@ fn naive_matrix_multiplication(
     i: Int,
     j: Int,
     k: Int,
-    m: TensorType,
-    n: TensorType,
-    p: TensorType,
+    m: LayoutTensor[float_dtype],
+    n: LayoutTensor[float_dtype],
+    p: LayoutTensor[float_dtype],
 ):
     row = block_dim.y * block_idx.y + thread_idx.y
     col = block_dim.x * block_idx.x + thread_idx.x

--- a/gpu-functions-mojo/grayscale.mojo
+++ b/gpu-functions-mojo/grayscale.mojo
@@ -14,11 +14,11 @@
 
 from gpu.host import Dim
 from gpu.id import block_dim, block_idx, thread_idx
+from layout import LayoutTensor
 from math import ceildiv
 from max.driver import (
     Accelerator,
     Device,
-    DynamicTensor,
     Tensor,
     accelerator,
     cpu,
@@ -28,7 +28,6 @@ from sys import has_nvidia_gpu_accelerator
 alias channel_dtype = DType.uint8
 alias internal_float_dtype = DType.float32
 alias tensor_rank = 3
-alias TensorType = DynamicTensor[type=channel_dtype, rank=tensor_rank].Type
 
 
 def print_image[h: Int, w: Int](t: Tensor[channel_dtype, 3]):
@@ -48,8 +47,8 @@ def print_image[h: Int, w: Int](t: Tensor[channel_dtype, 3]):
 fn color_to_grayscale_conversion(
     width: Int,
     height: Int,
-    image: TensorType,
-    out: TensorType,
+    image: LayoutTensor[channel_dtype],
+    out: LayoutTensor[channel_dtype],
 ):
     """Converting each RGB pixel to grayscale, parallelized across the output tensor on the GPU.
     """
@@ -116,8 +115,8 @@ def main():
             gpu_device,
             IMAGE_WIDTH,
             IMAGE_HEIGHT,
-            rgb_tensor.unsafe_slice(),
-            gray_tensor.unsafe_slice(),
+            rgb_tensor.to_layout_tensor(),
+            gray_tensor.to_layout_tensor(),
             grid_dim=Dim(num_col_blocks, num_row_blocks),
             block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
         )

--- a/gpu-functions-mojo/mandelbrot.mojo
+++ b/gpu-functions-mojo/mandelbrot.mojo
@@ -15,13 +15,13 @@ from collections.string import StringSlice
 from complex import ComplexSIMD
 from gpu.host import Dim
 from gpu.id import thread_idx, block_dim, block_idx
+from layout import LayoutTensor
 from math import ceildiv
-from max.driver import Accelerator, DynamicTensor, Tensor, accelerator, cpu
+from max.driver import Accelerator, Tensor, accelerator, cpu
 from sys import has_nvidia_gpu_accelerator
 
 alias float_dtype = DType.float32
 alias int_dtype = DType.int32
-alias TensorType = DynamicTensor[type=int_dtype, rank=2].Type
 
 
 def draw_mandelbrot[h: Int, w: Int](t: Tensor[int_dtype, 2], max: Int):
@@ -46,7 +46,7 @@ fn mandelbrot(
     scale_x: Scalar[float_dtype],
     scale_y: Scalar[float_dtype],
     max_iterations: Scalar[int_dtype],
-    out: TensorType,
+    out: LayoutTensor[int_dtype],
 ):
     """The per-element calculation of iterations to escape in the Mandelbrot set.
     """
@@ -119,7 +119,7 @@ def main():
             SCALE_X,
             SCALE_Y,
             MAX_ITERATIONS,
-            out_tensor.unsafe_slice(),
+            out_tensor.to_layout_tensor(),
             grid_dim=Dim(num_col_blocks, num_row_blocks),
             block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
         )

--- a/gpu-functions-mojo/naive_matrix_multiplication.mojo
+++ b/gpu-functions-mojo/naive_matrix_multiplication.mojo
@@ -14,11 +14,11 @@
 
 from gpu.host import Dim
 from gpu.id import block_dim, block_idx, thread_idx
+from layout import LayoutTensor
 from math import ceildiv
 from max.driver import (
     Accelerator,
     Device,
-    DynamicTensor,
     Tensor,
     accelerator,
     cpu,
@@ -27,16 +27,15 @@ from sys import has_nvidia_gpu_accelerator
 
 alias float_dtype = DType.float32
 alias tensor_rank = 2
-alias TensorType = DynamicTensor[type=float_dtype, rank=tensor_rank].Type
 
 
 fn naive_matrix_multiplication(
     i: Int,
     j: Int,
     k: Int,
-    m: TensorType,
-    n: TensorType,
-    p: TensorType,
+    m: LayoutTensor[float_dtype],
+    n: LayoutTensor[float_dtype],
+    p: LayoutTensor[float_dtype],
 ):
     """Naive matrix multiplication of M_ij x N_jk = P_ik."""
     row = block_dim.y * block_idx.y + thread_idx.y
@@ -102,9 +101,9 @@ def main():
             I,
             J,
             K,
-            m_tensor.unsafe_slice(),
-            n_tensor.unsafe_slice(),
-            p_tensor.unsafe_slice(),
+            m_tensor.to_layout_tensor(),
+            n_tensor.to_layout_tensor(),
+            p_tensor.to_layout_tensor(),
             grid_dim=Dim(num_col_blocks, num_row_blocks),
             block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
         )

--- a/gpu-functions-mojo/vector_addition.mojo
+++ b/gpu-functions-mojo/vector_addition.mojo
@@ -13,11 +13,11 @@
 
 from gpu.host import Dim
 from gpu.id import block_dim, block_idx, thread_idx
+from layout import LayoutTensor
 from math import ceildiv
 from max.driver import (
     Accelerator,
     Device,
-    DynamicTensor,
     Tensor,
     accelerator,
     cpu,
@@ -26,14 +26,13 @@ from sys import has_nvidia_gpu_accelerator
 
 alias float_dtype = DType.float32
 alias tensor_rank = 1
-alias TensorType = DynamicTensor[type=float_dtype, rank=tensor_rank].Type
 
 
 fn vector_addition(
     length: Int,
-    lhs: TensorType,
-    rhs: TensorType,
-    out: TensorType,
+    lhs: LayoutTensor[float_dtype],
+    rhs: LayoutTensor[float_dtype],
+    out: LayoutTensor[float_dtype],
 ):
     """The calculation to perform across the vector on the GPU."""
     tid = block_dim.x * block_idx.x + thread_idx.x
@@ -85,9 +84,9 @@ def main():
         gpu_function(
             gpu_device,
             VECTOR_WIDTH,
-            lhs_tensor.unsafe_slice(),
-            rhs_tensor.unsafe_slice(),
-            out_tensor.unsafe_slice(),
+            lhs_tensor.to_layout_tensor(),
+            rhs_tensor.to_layout_tensor(),
+            out_tensor.to_layout_tensor(),
             grid_dim=Dim(num_blocks),
             block_dim=Dim(BLOCK_SIZE),
         )


### PR DESCRIPTION
The datatypes for custom ops changed recently from `ManagedTensorSlice` to `OutputTensor` and `InputTensor`. This updates all code around the custom ops and benchmarks to build correctly on the latest MAX nightlies.

Additionally, we've reworked the GPU function examples to be cleaner through the use of LayoutTensor, so this brings those updates back into this recipe.