### PR TITLE
Fix tensor core instruction shape

### DIFF
--- a/custom-ops-matrix-multiplication/benchmarks.mojo
+++ b/custom-ops-matrix-multiplication/benchmarks.mojo
@@ -167,6 +167,7 @@ def matmul():
         bench_matmul_kernel["tiled_register"]()
         bench_matmul_kernel["block_tiled"]()
         bench_matmul_kernel["block_tiled_vectorized"]()
+        bench_matmul_kernel["tensor_core"]()
 
     bench.config.verbose_metric_names = False
     print(bench)

--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -968,6 +968,7 @@ struct MatrixMultiplication[algorithm: StringLiteral]:
                     block_dim=(NUM_THREADS),
                 )
             elif algorithm == "tensor_core":
+                constrained[""]
                 alias BM = 64
                 alias BN = 64
                 alias BK = 32
@@ -975,7 +976,7 @@ struct MatrixMultiplication[algorithm: StringLiteral]:
                 alias WN = 32
                 alias MMA_M = 16
                 alias MMA_N = 8
-                alias MMA_K = 8
+                alias MMA_K = 4
                 alias NUM_WARPS = (BM // WM) * (BN // WN)
                 gpu_ctx.enqueue_function[
                     tensor_core_matrix_multiplication[

--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -968,7 +968,6 @@ struct MatrixMultiplication[algorithm: StringLiteral]:
                     block_dim=(NUM_THREADS),
                 )
             elif algorithm == "tensor_core":
-                constrained[""]
                 alias BM = 64
                 alias BN = 64
                 alias BK = 32


### PR DESCRIPTION
## Major Changes
1. Change MMA_K Instruction shape for the "tensor_core" benchmark to conform with shape+stride of Inputs
ref: https://github.com/NVIDIA/cutlass/blob/df18f5e4f5de76bed8be1de8e4c245f2f5ec3020/include/cute/atom/mma_traits_sm80.hpp#L147-L160

## Minor Changes
1. Registered a "tensor_core" benchmark to benchmarks