### PR TITLE
Switch GPU programming recipes to use Magic retrieval, pin to current MAX nightly

### DIFF
--- a/custom-ops-ai-applications/README.md
+++ b/custom-ops-ai-applications/README.md
@@ -45,11 +45,11 @@ ensure your system meets
 
 ## Quick start
 
-1. Download the code for this recipe using git:
+1. Download this recipe using Magic:
 
 ```bash
-git clone https://github.com/modular/max-recipes.git
-cd max-recipes/custom-ai-applications
+magic init custom-ops-ai-applications --from custom-ops-ai-applications@0.0.1
+cd custom-ops-ai-applications
 ```
 
 2. Run the examples:

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -28,4 +28,4 @@ fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = ">=25.2.0.dev2025022205"
+max = "==25.2.0.dev2025031005"

--- a/custom-ops-introduction/README.md
+++ b/custom-ops-introduction/README.md
@@ -44,11 +44,11 @@ ensure your system meets
 
 ## Quick start
 
-1. Download the code for this recipe using git:
+1. Download this recipe using Magic:
 
 ```bash
-git clone https://github.com/modular/max-recipes.git
-cd max-recipes/custom-ops-introduction
+magic init custom-ops-introduction --from custom-ops-introduction@0.0.1
+cd custom-ops-introduction
 ```
 
 2. Run each of the examples:

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -28,4 +28,4 @@ mandelbrot = { cmd = "python mandelbrot.py", depends-on = ["package"] }
 vector_addition = { cmd = "python vector_addition.py", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = ">=25.2.0.dev2025022205"
+max = "==25.2.0.dev2025031005"

--- a/custom-ops-matrix-multiplication/README.md
+++ b/custom-ops-matrix-multiplication/README.md
@@ -45,11 +45,11 @@ ensure your system meets
 
 ## Quick start
 
-1. Download the code for this recipe using git:
+1. Download this recipe using Magic:
 
 ```bash
-git clone https://github.com/modular/max-recipes.git
-cd max-recipes/custom-ops-matrix-multiplication
+magic init custom-ops-matrix-multiplication --from custom-ops-matrix-multiplication@0.0.1
+cd custom-ops-matrix-multiplication
 ```
 
 2. Run the example:

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -27,4 +27,4 @@ matrix_multiplication = { cmd = "python matrix_multiplication.py", depends-on = 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = ">=25.2.0.dev2025022205"
+max = "==25.2.0.dev2025031005"

--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -44,11 +44,11 @@ These examples require a MAX-compatible GPU satisfying
 
 ## Quick start
 
-1. Download the code for this recipe using `git`:
+1. Download this recipe using Magic:
 
     ```bash
-    git clone https://github.com/modular/max-recipes.git
-    cd max-recipes/gpu-functions-mojo
+    magic init gpu-functions-mojo --from gpu-functions-mojo@0.0.1
+    cd gpu-functions-mojo
     ```
 
 1. Run the examples:

--- a/gpu-functions-mojo/pyproject.toml
+++ b/gpu-functions-mojo/pyproject.toml
@@ -28,4 +28,4 @@ naive_matrix_multiplication = { cmd = "mojo naive_matrix_multiplication.mojo" }
 mandelbrot = { cmd = "mojo mandelbrot.mojo" }
 
 [tool.pixi.dependencies]
-max = ">=25.2.0.dev2025022205"
+max = "==25.2.0.dev2025031005"


### PR DESCRIPTION
Magic 0.7.1 will add the ability to retrieve recipes directly, so this converts the installation instructions over to use the new retrieval functionality rather than Git cloning.

To stabilize the GPU programming examples, they have all been pinned to today's 25.2.0.dev2025031005 MAX nightly. I hand-verified each target in all of these repositories to run on an NVIDIA GPU as of that nightly. We can move them up to newer nightlies once those are tested to add new features required for the demos.