### PR TITLE
[docs] Initial copyediting and reformatting for gpu_functions README

### DIFF
--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -69,7 +69,7 @@ optimized AI models, to the computational graphs that define those models, to
 direct GPU programming in the Mojo language. You can use whatever level of
 abstraction best suits your needs in MAX.
 
-[Mojo](https://docs.modular.com/mojo/manual/) is a Python-family language that
+[Mojo](https://docs.modular.com/mojo/manual/) is a Python-family language
 built for high-performance computing. It allows you to write custom
 algorithms for GPUs without the use of CUDA or other vendor-specific libraries.
 All of the operations that power AI models within MAX are written in Mojo.

--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -2,16 +2,16 @@
 
 In this recipe, we will cover:
 
-* Writing thread-parallel GPU functions in Mojo.
-* Compiling and dispatching these functions to a GPU using the MAX Driver API.
-* Translating common CUDA C programming patterns to MAX and Mojo.
+- Writing thread-parallel GPU functions in Mojo
+- Compiling and dispatching these functions to a GPU using the MAX Driver API
+- Translating common CUDA C programming patterns to MAX and Mojo
 
-We'll walk through four GPU programming examples that
+We'll walk through four GPU programming examples:
 
-* perform basic vector addition,
-* convert a color image to grayscale,
-* do a naive matrix multiplication,
-* and calculate the Mandelbrot set fractal.
+- Performing basic vector addition
+- Converting a color image to grayscale
+- Performing naive matrix multiplication
+- Calculating the Mandelbrot set fractal
 
 Let's get started.
 
@@ -34,159 +34,167 @@ magic self-update
 
 ### GPU requirements
 
-These examples require a MAX-compatible GPU, satisfying
+These examples require a MAX-compatible GPU satisfying
 [these requirements](https://docs.modular.com/max/faq/#gpu-requirements):
 
-* Officially supported GPUs: NVIDIA Ampere A-series (A100/A10), or Ada
+- Officially supported GPUs: NVIDIA Ampere A-series (A100/A10), or Ada
   L4-series (L4/L40) data center GPUs. Unofficially, RTX 30XX and 40XX series
   GPUs have been reported to work well with MAX.
-* NVIDIA GPU driver version 555 or higher. [Installation guide here](https://www.nvidia.com/download/index.aspx).
+- NVIDIA GPU driver version 555 or higher. [Installation guide here](https://www.nvidia.com/download/index.aspx).
 
 ## Quick start
 
-1. Download the code for this recipe using git:
+1. Download the code for this recipe using `git`:
 
-```bash
-git clone https://github.com/modular/max-recipes.git
-cd max-recipes/gpu-functions-mojo
-```
+    ```bash
+    git clone https://github.com/modular/max-recipes.git
+    cd max-recipes/gpu-functions-mojo
+    ```
 
-2. Run the examples:
+1. Run the examples:
 
-```bash
-magic run vector_addition
-magic run grayscale
-magic run naive_matrix_multiplication
-magic run mandelbrot
-```
+    ```bash
+    magic run vector_addition
+    magic run grayscale
+    magic run naive_matrix_multiplication
+    magic run mandelbrot
+    ```
 
 ## Compiling and running GPU functions using the Mojo Driver API
 
 MAX is a flexible, hardware-independent framework for programming GPUs and
 CPUs. It lets you get the most out of accelators without requiring
-architecture-specific frameworks like CUDA. MAX has many levels. from highly
+architecture-specific frameworks like CUDA. MAX has many levels, from highly
 optimized AI models, to the computational graphs that define those models, to
 direct GPU programming in the Mojo language. You can use whatever level of
 abstraction best suits your needs in MAX.
 
 [Mojo](https://docs.modular.com/mojo/manual/) is a Python-family language that
-has been built for high-performance computing. It allows you to write custom
+built for high-performance computing. It allows you to write custom
 algorithms for GPUs without the use of CUDA or other vendor-specific libraries.
 All of the operations that power AI models within MAX are written in Mojo.
 
-We'll demonstrate an entry point into GPU programming with MAX where individual
-thread-based functions can be defined, compiled, and dispatched onto a GPU.
-This is powered by the MAX Driver API, which handles all the hardware-specific
-details of allocating and transferring memory between host and accelerator, as
-well as compilation and execution of accelerator-targeted functions.
+We'll demonstrate an entry point into GPU programming with MAX allowing you to
+define, compile, and dispatch onto a GPU individual thread-based functions. This
+is powered by the [MAX Driver](https://docs.modular.com/max/api/mojo/driver/)
+API, which handles all the hardware-specific details of allocating and
+transferring memory between host and accelerator, as well as compilation and
+execution of accelerator-targeted functions.
 
 The first three examples in this recipe show common starting points for
 thread-based GPU programming. They follow the first three examples in the
 popular GPU programming textbook
-["Programming Massively Parallel Processors"](https://www.sciencedirect.com/book/9780323912310/programming-massively-parallel-processors): 
+[*Programming Massively Parallel Processors*](https://www.sciencedirect.com/book/9780323912310/programming-massively-parallel-processors):
 
-* Parallel addition of two vectors
-* Conversion of a red-green-blue image to grayscale
-* A naive matrix multiplication, with no hardware-specific optimization
+- Parallel addition of two vectors
+- Conversion of a red-green-blue image to grayscale
+- Naive matrix multiplication, with no hardware-specific optimization
+
+The final example demonstrates calculating the Mandelbrot set on the GPU.
 
 ### Basic vector addition
 
 The common "hello world" example used for data-parallel programming is the
-addition of each element in two vectors. Let's take a look at how that can be
-defined in MAX.
+addition of each element in two vectors. Let's take a look at how you can
+implement that in MAX.
 
-The function itself is very simple, running once per thread, adding each
-element in the two input vectors that correspond to that thread ID, and storing
-the result in the output vector at the matching location. If a block of threads
-is dispatched that is wider than the vector length, no work is performed by
-threads past the end of the vector.
+1. Define the vector addition function.
 
-```mojo
-fn vector_addition(
-    length: Int,
-    lhs: LayoutTensor[float_dtype],
-    rhs: LayoutTensor[float_dtype],
-    out: LayoutTensor[float_dtype],
-):
-    tid = block_dim.x * block_idx.x + thread_idx.x
-    if tid < length:
-        var result = lhs[tid] + rhs[tid]
-        out[tid] = result
-```
+    The function itself is very simple, running once per thread, adding each
+    element in the two input vectors that correspond to that thread ID, and
+    storing the result in the output vector at the matching location. If a block
+    of threads is dispatched that is wider than the vector length, no work is
+    performed by threads past the end of the vector.
 
-To run this function on the GPU, input and output vectors need to be
-allocated, the function compiled and dispatched, and the results returned.
+    ```mojo
+    fn vector_addition(
+        length: Int,
+        lhs: LayoutTensor[float_dtype],
+        rhs: LayoutTensor[float_dtype],
+        out: LayoutTensor[float_dtype],
+    ):
+        tid = block_dim.x * block_idx.x + thread_idx.x
+        if tid < length:
+            var result = lhs[tid] + rhs[tid]
+            out[tid] = result
+    ```
 
-As a first step, a reference to the host (CPU) and accelerator (GPU) devices
-needs to be obtained:
+1. Obtain a reference to the host (CPU) and accelerator (GPU) devices.
 
-```mojo
-gpu_device = accelerator()
-host_device = cpu()
-```
+    ```mojo
+    gpu_device = accelerator()
+    host_device = cpu()
+    ```
 
-If no MAX-compatible accelerator has been found, this will error out and
-indicate as such.
+    If no MAX-compatible accelerator is found, this exits with an error.
 
-Next, the left-hand-side and right-hand-side vectors need to be allocated on
-the CPU, initialized with values, and then moved to the GPU for use by our
-function. This is done using the MAX Driver API's `Tensor` type
+1. Allocate input and output vectors.
 
-```mojo
-alias float_dtype = DType.float32
-alias tensor_rank = 1
-alias VECTOR_WIDTH = 10
+    The left-hand-side and right-hand-side vectors need to be allocated on the
+    CPU, initialized with values, and then moved to the GPU for use by our
+    function. This is done using the MAX Driver API's
+    [`Tensor`](https://docs.modular.com/max/api/mojo/driver/tensor/Tensor) type.
 
-lhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
-rhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
+    ```mojo
+    alias float_dtype = DType.float32
+    alias tensor_rank = 1
+    alias VECTOR_WIDTH = 10
 
-for i in range(VECTOR_WIDTH):
-    lhs_tensor[i] = 1.25
-    rhs_tensor[i] = 2.5
+    lhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
+    rhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
 
-lhs_tensor = lhs_tensor.move_to(gpu_device)
-rhs_tensor = rhs_tensor.move_to(gpu_device)
-```
+    for i in range(VECTOR_WIDTH):
+        lhs_tensor[i] = 1.25
+        rhs_tensor[i] = 2.5
 
-A tensor that hosts the result of the calculation is allocated on the GPU:
+    lhs_tensor = lhs_tensor.move_to(gpu_device)
+    rhs_tensor = rhs_tensor.move_to(gpu_device)
+    ```
 
-```mojo
-out_tensor = Tensor[float_dtype, tensor_rank](
-    (VECTOR_WIDTH), gpu_device
-)
-```
+    A tensor to hold the result of the calculation is allocated on the GPU:
 
-The actual `vector_addition` function we want to run on the GPU is compiled and
-dispatched across a grid, divided into blocks of threads. All arguments to this
-GPU function are provided here, in an order that corresponds to their location
-in the function signature. Note that in MAX, the GPU function is compiled for
-the GPU at the time of compilation of the Mojo file containing it.
+    ```mojo
+    out_tensor = Tensor[float_dtype, tensor_rank](
+        (VECTOR_WIDTH), gpu_device
+    )
+    ```
 
-```mojo
-gpu_function = Accelerator.compile[vector_addition](gpu_device)
+1. Compile and dispatch the function.
 
-alias BLOCK_SIZE = 16
-var num_blocks = ceildiv(VECTOR_WIDTH, BLOCK_SIZE)
+    The actual `vector_addition()` function we want to run on the GPU is
+    compiled and dispatched across a grid, divided into blocks of threads. All
+    arguments to this GPU function are provided here, in an order that
+    corresponds to their location in the function signature. Note that in MAX,
+    the GPU function is compiled for the GPU at the time of compilation of the
+    Mojo file containing it.
 
-gpu_function(
-    gpu_device,
-    VECTOR_WIDTH,
-    lhs_tensor.to_layout_tensor(),
-    rhs_tensor.to_layout_tensor(),
-    out_tensor.to_layout_tensor(),
-    grid_dim=Dim(num_blocks),
-    block_dim=Dim(BLOCK_SIZE),
-)
-```
+    ```mojo
+    gpu_function = Accelerator.compile[vector_addition](gpu_device)
 
-Finally, the results of the calculation are moved from the GPU back to the host
-to be examined:
+    alias BLOCK_SIZE = 16
+    var num_blocks = ceildiv(VECTOR_WIDTH, BLOCK_SIZE)
 
-```mojo
-out_tensor = out_tensor.move_to(host_device)
+    gpu_function(
+        gpu_device,
+        VECTOR_WIDTH,
+        lhs_tensor.to_layout_tensor(),
+        rhs_tensor.to_layout_tensor(),
+        out_tensor.to_layout_tensor(),
+        grid_dim=Dim(num_blocks),
+        block_dim=Dim(BLOCK_SIZE),
+    )
+    ```
 
-print("Resulting vector:", out_tensor)
-```
+1. Return the results.
+
+    Finally, the results of the calculation are moved from the GPU back to the
+    host to be examined:
+
+    ```mojo
+    out_tensor = out_tensor.move_to(host_device)
+
+    print("Resulting vector:", out_tensor)
+    ```
 
 To try out this example yourself, run it using the following command:
 
@@ -194,16 +202,17 @@ To try out this example yourself, run it using the following command:
 magic run vector_addition
 ```
 
-You should observe a vector of all 3.75. Experiment with changing the vector
-length, the block size, and other parameters and see how the calculation
-scales.
+For this initial example, the output you see should be a vector where all the
+elements are `3.75`. Experiment with changing the vector length, the block size,
+and other parameters to see how the calculation scales.
 
 ### Conversion of a color image to grayscale
 
 As a slightly more complex example, the next step in this recipe shows how to
 convert a red-green-blue (RGB) color image into grayscale. This uses a rank-3
 tensor to host the 2-D image and the color channels at each pixel. The inputs
-start with three color channels, and the output only has a single grayscale channel.
+start with three color channels, and the output has only a single grayscale
+channel.
 
 The calculation performed is a common reduction to luminance using weighted
 values for the three channels:
@@ -212,7 +221,7 @@ values for the three channels:
 gray = 0.21 * red + 0.71 * green + 0.07 * blue
 ```
 
-And this is the per-thread function that expresses this to be run on the GPU:
+And here is the per-thread function to perform this on the GPU:
 
 ```mojo
 fn color_to_grayscale_conversion(
@@ -235,7 +244,7 @@ fn color_to_grayscale_conversion(
 
 The setup, compilation, and execution of this function is much the same as in
 the previous example, but in this case we're using rank-3 instead of rank-1
-`Tensor`s to hold the values. Also, the function is dispatched over a 2-D grid
+`Tensor`s to hold the values. Also, we dispatch the function over a 2-D grid
 of block, which looks like the following:
 
 ```mojo
@@ -254,7 +263,7 @@ gpu_function(
 )
 ```
 
-To run this example, use the command:
+To run this example, run this command:
 
 ```sh
 magic run grayscale
@@ -291,14 +300,14 @@ The overall setup and execution of this function are extremely similar to the
 previous example, with the primary change being the function that is run on the
 GPU.
 
-To try out this example, run the command:
+To try out this example, run this command:
 
 ```sh
 magic run naive_matrix_multiplication
 ```
 
 You will see the two input matrices printed to the console, as well as the
-result of their multiplication. As with the previous examples, try out changing
+result of their multiplication. As with the previous examples, try changing
 the sizes of the matrices and how they are dispatched on the GPU.
 
 ### Calculating the Mandelbrot set fractal
@@ -350,7 +359,7 @@ and the number of iterations to escape (or not, if the maximum is hit) is then
 returned for each location in the grid.
 
 The area to examine in complex space, the resolution of the grid, and the
-maximum number of iterations, are all provided as constants:
+maximum number of iterations are all provided as constants:
 
 ```mojo
 alias MIN_X: Scalar[float_dtype] = -2.0
@@ -362,7 +371,7 @@ alias SCALE_Y = (MAX_Y - MIN_Y) / GRID_HEIGHT
 alias MAX_ITERATIONS = 100
 ```
 
-The Mandelbrot set can be calculated on GPU using this command:
+You can calculate the Mandelbrot set on the GPU using this command:
 
 ```sh
 magic run mandelbrot
@@ -371,7 +380,7 @@ magic run mandelbrot
 The result should be an ASCII art depiction of the region covered by the
 calculation:
 
-```
+```output
 ...................................,,,,c@8cc,,,.............
 ...............................,,,,,,cc8M @Mjc,,,,..........
 ............................,,,,,,,ccccM@aQaM8c,,,,,........
@@ -410,7 +419,7 @@ is a programming model that is very familiar to those used to CUDA C, and we
 have used a series of common examples to show how to map concepts from CUDA to
 MAX.
 
-MAX has far more power available for fully utilizing GPUs through 
+MAX has far more power available for fully utilizing GPUs through
 [building computational graphs](https://docs.modular.com/max/tutorials/get-started-with-max-graph-in-python)
 and then [defining custom operations](https://docs.modular.com/max/tutorials/build-custom-ops)
 in Mojo using hardware-optimized abstractions. MAX is an extremely flexible
@@ -420,14 +429,14 @@ programming in MAX and Mojo, but there's much more to explore!
 
 ## Next Steps
 
-* Try applying GPU programming in MAX for more complex workloads via tutorials
+- Try applying GPU programming in MAX for more complex workloads via tutorials
   on the [MAX Graph API](https://docs.modular.com/max/tutorials/get-started-with-max-graph-in-python)
   and [defining custom GPU graph operations in Mojo](https://docs.modular.com/max/tutorials/build-custom-ops).
 
-* Explore MAX's [documentation](https://docs.modular.com/max/) for additional
+- Explore MAX's [documentation](https://docs.modular.com/max/) for additional
   features. The [`gpu`](https://docs.modular.com/mojo/stdlib/gpu/) module has
   detail on Mojo's GPU programming functions and types.
 
-* Join our [Modular Forum](https://forum.modular.com/) and [Discord community](https://discord.gg/modular) to share your experiences and get support.
+- Join our [Modular Forum](https://forum.modular.com/) and [Discord community](https://discord.gg/modular) to share your experiences and get support.
 
 We're excited to see what you'll build with MAX! Share your projects and experiences with us using `#ModularAI` on social media.


### PR DESCRIPTION
I did some copyediting and reformatting of the `README.md` for the `gpu_functions` recipe.

In the corresponding Linear ticket [DOCS-780: Provide a review of the Direct GPU Kernels with Mojo recipe](https://linear.app/modularml/issue/DOCS-780/provide-a-review-of-the-direct-gpu-kernels-with-mojo-recipe), I raised a question about whether this should be both linking to the GPU requirements **and** explicitly stating them inline. But I also noticed that some of the other recipes do the same thing, so I decided to leave it as is for now.