### PR TITLE
Have programmability recipes use the latest version on Magic retrieval

### DIFF
--- a/custom-ops-ai-applications/README.md
+++ b/custom-ops-ai-applications/README.md
@@ -48,7 +48,7 @@ ensure your system meets
 1. Download this recipe using Magic:
 
 ```bash
-magic init custom-ops-ai-applications --from custom-ops-ai-applications@0.0.1
+magic init custom-ops-ai-applications --from custom-ops-ai-applications
 cd custom-ops-ai-applications
 ```
 

--- a/custom-ops-introduction/README.md
+++ b/custom-ops-introduction/README.md
@@ -47,7 +47,7 @@ ensure your system meets
 1. Download this recipe using Magic:
 
 ```bash
-magic init custom-ops-introduction --from custom-ops-introduction@0.0.1
+magic init custom-ops-introduction --from custom-ops-introduction
 cd custom-ops-introduction
 ```
 

--- a/custom-ops-matrix-multiplication/README.md
+++ b/custom-ops-matrix-multiplication/README.md
@@ -48,7 +48,7 @@ ensure your system meets
 1. Download this recipe using Magic:
 
 ```bash
-magic init custom-ops-matrix-multiplication --from custom-ops-matrix-multiplication@0.0.1
+magic init custom-ops-matrix-multiplication --from custom-ops-matrix-multiplication
 cd custom-ops-matrix-multiplication
 ```
 

--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -92,6 +92,10 @@ popular GPU programming textbook
 
 The final example demonstrates calculating the Mandelbrot set on the GPU.
 
+These examples also work hand-in-hand with
+[our guide to the basics of GPU programming in Mojo](https://docs.modular.com/mojo/manual/gpu/gpu-basics),
+which we recommend reading alongside this recipe.
+
 ### Basic vector addition
 
 The common "hello world" example used for data-parallel programming is the
@@ -427,6 +431,8 @@ you've been introduced to the very basics of getting started with GPU
 programming in MAX and Mojo, but there's much more to explore!
 
 ## Next Steps
+
+- Read [our detailed guide to the basics of GPU programming](https://docs.modular.com/mojo/manual/gpu/gpu-basics).
 
 - Try applying GPU programming in MAX for more complex workloads via tutorials
   on the [MAX Graph API](https://docs.modular.com/max/tutorials/get-started-with-max-graph-in-python)

--- a/gpu-functions-mojo/README.md
+++ b/gpu-functions-mojo/README.md
@@ -47,7 +47,7 @@ These examples require a MAX-compatible GPU satisfying
 1. Download this recipe using Magic:
 
     ```bash
-    magic init gpu-functions-mojo --from gpu-functions-mojo@0.0.1
+    magic init gpu-functions-mojo --from gpu-functions-mojo
     cd gpu-functions-mojo
     ```
 
@@ -115,8 +115,7 @@ implement that in MAX.
     ):
         tid = block_dim.x * block_idx.x + thread_idx.x
         if tid < length:
-            var result = lhs[tid] + rhs[tid]
-            out[tid] = result
+            out[tid] = lhs[tid] + rhs[tid]
     ```
 
 1. Obtain a reference to the host (CPU) and accelerator (GPU) devices.
@@ -293,7 +292,7 @@ fn naive_matrix_multiplication(
 
     if row < i and col < k:
         for j_index in range(j):
-            p[row, col] = p[row, col] + m[row, j_index] * n[j_index, col]
+            p[row, col] += m[row, j_index] * n[j_index, col]
 ```
 
 The overall setup and execution of this function are extremely similar to the

--- a/gpu-functions-mojo/naive_matrix_multiplication.mojo
+++ b/gpu-functions-mojo/naive_matrix_multiplication.mojo
@@ -47,7 +47,7 @@ fn naive_matrix_multiplication[
 
     if row < i and col < k:
         for j_index in range(j):
-            p[row, col] = p[row, col] + m[row, j_index] * n[j_index, col]
+            p[row, col] += m[row, j_index] * n[j_index, col]
 
 
 def main():

--- a/gpu-functions-mojo/vector_addition.mojo
+++ b/gpu-functions-mojo/vector_addition.mojo
@@ -41,8 +41,7 @@ fn vector_addition[
     """The calculation to perform across the vector on the GPU."""
     tid = block_dim.x * block_idx.x + thread_idx.x
     if tid < length:
-        var result = lhs[tid] + rhs[tid]
-        out[tid] = result
+        out[tid] = lhs[tid] + rhs[tid]
 
 
 def main():


### PR DESCRIPTION
In the just-released Magic 0.7.2, version tags are no longer needed for retrieval of Magic recipes, it will pull the most recent version in the repository by default. This removes those tags to make the READMEs version-independent.

Additionally, Abdul pointed out a few places where the examples could be simplified with no functional changes, so those edits have been made in the code and READMEs.