### PR TITLE
Break down discussion of tiled kernel, remove excess code.

### DIFF
--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -326,12 +326,10 @@ fn tiled_register_matrix_multiplication[
     # Calculate the column and row indices for each thread.
     var col = thread_idx.x % BN
     var row = thread_idx.x // BN
-    var bidx = block_idx.x
-    var bidy = block_idx.y
 
     # Get the tile of the output matrix C that this thread is
     # responsible for computing.
-    var dst = c.tile[BM, BN](bidy, bidx).tile[TM, 1](row, col)
+    var dst = c.tile[BM, BN](block_idx.y, block_idx.x).tile[TM, 1](row, col)
 
     # Allocate shared memory for tiles of A and B.
     var a_smem = tb[dtype]().row_major[BM, BK]().shared().alloc()
@@ -436,10 +434,8 @@ fn block_tiled_matrix_multiplication[
     """
     var partition_col = thread_idx.x % (BN // TN)
     var partition_row = thread_idx.x // (BN // TN)
-    var bidx = block_idx.x
-    var bidy = block_idx.y
 
-    var dst = c.tile[BM, BN](bidy, bidx).tile[TM, TN](
+    var dst = c.tile[BM, BN](block_idx.y, block_idx.x).tile[TM, TN](
         partition_row, partition_col
     )
 
@@ -536,12 +532,11 @@ fn block_tiled_vectorized_matrix_multiplication[
     alias simd_width = simdwidthof[dtype]()
     var partition_col = thread_idx.x % (BN // TN)
     var partition_row = thread_idx.x // (BN // TN)
-    var bidx = block_idx.x
-    var bidy = block_idx.y
+
 
     # Get the tile of the output matrix C that this thread is responsible
     # for computing.
-    var dst = c.tile[BM, BN](bidy, bidx).tile[TM, TN](
+    var dst = c.tile[BM, BN](block_idx.y, block_idx.x).tile[TM, TN](
         partition_row, partition_col
     )
     var dst_vec = dst.vectorize[1, simd_width]()


### PR DESCRIPTION
This makes a couple of changes that I think improve the recipe, some of which might be controversial.

- Remove the kernel signatures for all the kernels except the first one and the last one. Kernels 2-6 have almost the same signature, and I note the addition of new parameters to the signature.
- In kernel 3, break down the code sample and explain it stepwise. The next 3 kernels all use the same basic structure.
- Remove the `bidx` and `bidy` temporary variables, which were only used in one place in each kernel. Removing them made the kernels more consistent.

@BradLarson feel free to merge this if it feels like an overall improvement to you. If you're on the fence, let's leave it and I can rework it post-GTC.