### PR TITLE
Lock max and max-pipelines versions to latest nightly

### DIFF
--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -28,4 +28,4 @@ fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031005"
+max = "==25.2.0.dev2025031705"

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -28,4 +28,4 @@ mandelbrot = { cmd = "python mandelbrot.py", depends-on = ["package"] }
 vector_addition = { cmd = "python vector_addition.py", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031005"
+max = "==25.2.0.dev2025031705"

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -27,4 +27,4 @@ matrix_multiplication = { cmd = "python matrix_multiplication.py", depends-on = 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031005"
+max = "==25.2.0.dev2025031705"

--- a/gpu-functions-mojo/pyproject.toml
+++ b/gpu-functions-mojo/pyproject.toml
@@ -28,4 +28,4 @@ naive_matrix_multiplication = { cmd = "mojo naive_matrix_multiplication.mojo" }
 mandelbrot = { cmd = "mojo mandelbrot.mojo" }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031005"
+max = "==25.2.0.dev2025031705"

--- a/max-serve-anythingllm/pyproject.toml
+++ b/max-serve-anythingllm/pyproject.toml
@@ -41,7 +41,7 @@ ui = "docker run -p $UI_PORT:3001 --name $UI_CONTAINER_NAME --cap-add SYS_ADMIN 
 clean = "pkill -f \"max-pipelines serve\" || true && lsof -ti:$MAX_SERVE_PORT,$UI_PORT | xargs -r kill -9 2>/dev/null || true && docker rm -f $UI_CONTAINER_NAME 2>/dev/null || true"
 
 [tool.pixi.dependencies]
-max-pipelines = ">=25.2.0.dev2025022718,<26"
+max-pipelines = "==25.2.0.dev2025031705"
 honcho = ">=2.0.0,<3"
 tomli = ">=2.2.1,<3"
 python-dotenv = ">=1.0.1,<2"

--- a/max-serve-open-webui/pyproject.toml
+++ b/max-serve-open-webui/pyproject.toml
@@ -54,7 +54,7 @@ max = "max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --m
 
 ### Dependencies
 [tool.pixi.feature.max.dependencies]
-max-pipelines = "*"
+max-pipelines = "==25.2.0.dev2025031705"
 
 
 ## ENVIRONMENT: BASE


### PR DESCRIPTION
Tested that these all work on ubunutu 22.04 GPU and macos CPU
