### PR TITLE
Updating the GPU programming examples to the latest MAX nightly

### DIFF
--- a/custom-ops-ai-applications/fused_attention.py
+++ b/custom-ops-ai-applications/fused_attention.py
@@ -22,7 +22,7 @@ from max.graph import Graph, TensorType, ops
 
 
 def main():
-    path = Path(__file__).parent / "operations.mojopkg"
+    mojo_kernels = Path(__file__).parent / "operations"
 
     dtype = DType.float32
 
@@ -44,6 +44,7 @@ def main():
             TensorType(dtype, shape=[N, D]),
             TensorType(dtype, shape=[N, D]),
         ],
+        custom_extensions=[mojo_kernels],
     ) as graph:
         q, k, v, *_ = graph.inputs
         results = ops.custom(
@@ -58,7 +59,7 @@ def main():
     device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
-    session = InferenceSession(devices=[device], custom_extensions=path)
+    session = InferenceSession(devices=[device])
 
     # Compile the graph.
     model = session.load(graph)

--- a/custom-ops-ai-applications/operations/fused_attention.mojo
+++ b/custom-ops-ai-applications/operations/fused_attention.mojo
@@ -83,7 +83,7 @@ struct FusedAttention:
         D: Int,  # Head dimension
         BN: Int,  # Dimension of blocks to split Q into
         BD: Int,  # Dimension of blocks to split K, V into
-        target: StringLiteral,  # "cpu" or "gpu"
+        target: StaticString,  # "cpu" or "gpu"
     ](
         output: OutputTensor[type=dtype, rank=rank],
         key: InputTensor[type=dtype, rank=rank],
@@ -212,7 +212,7 @@ fn fused_attention_cpu[
 
 @always_inline
 fn matmul[
-    target: StringLiteral,
+    target: StaticString,
     transpose_b: Bool = False,
 ](
     lhs: LayoutTensor,
@@ -223,7 +223,8 @@ fn matmul[
         MutableAnyOrigin,
         address_space = lhs.address_space,
         element_layout = lhs.element_layout,
-        layout_bitwidth = lhs.layout_bitwidth,
+        layout_int_type = lhs.layout_int_type,
+        linear_idx_type = lhs.linear_idx_type,
     ],
 ):
     res = __type_of(res).stack_allocation()

--- a/custom-ops-ai-applications/operations/top_k.mojo
+++ b/custom-ops-ai-applications/operations/top_k.mojo
@@ -53,7 +53,7 @@ struct TopK:
         rank: Int,
         //,  # Forces the previous two params to be inferred from the args
         K: Int,
-        target: StringLiteral,
+        target: StaticString,
     ](
         out_vals: OutputTensor[type=type, rank=rank],
         out_idxs: OutputTensor[type = DType.int32, rank=rank],

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -28,4 +28,4 @@ fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031705"
+max = "==25.3.0.dev2025041105"

--- a/custom-ops-ai-applications/top_k.py
+++ b/custom-ops-ai-applications/top_k.py
@@ -112,7 +112,7 @@ def main():
     args = parser.parse_args()
 
     # Get the path to our compiled custom ops
-    path = Path(__file__).parent / "operations.mojopkg"
+    mojo_kernels = Path(__file__).parent / "operations"
 
     # Initialize the next word frequency for each unique word
     frequencies = NextWordFrequency(INPUT_TEXT)
@@ -129,6 +129,7 @@ def main():
         "top_k_sampler",
         # The dtype and shape of the probabilities being passed in
         input_types=[TensorType(DType.float32, shape=[batch_size, K])],
+        custom_extensions=[mojo_kernels],
     ) as graph:
         # Take the probabilities as a single input to the graph.
         probs, *_ = graph.inputs
@@ -153,7 +154,7 @@ def main():
     device = CPU() if args.cpu or accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
-    session = InferenceSession(devices=[device], custom_extensions=path)
+    session = InferenceSession(devices=[device])
 
     # Compile the graph.
     model = session.load(graph)

--- a/custom-ops-introduction/README.md
+++ b/custom-ops-introduction/README.md
@@ -120,7 +120,7 @@ is defined in Mojo within `operations/add_one.mojo`:
 struct AddOne:
     @staticmethod
     fn execute[
-        target: StringLiteral,
+        target: StaticString,
     ](
         out: OutputTensor,
         x: InputTensor[type = out.type, rank = out.rank],
@@ -167,6 +167,7 @@ graph = Graph(
     input_types=[
         TensorType(dtype, shape=[rows, columns]),
     ],
+    custom_extensions=[mojo_kernels],
 )
 ```
 

--- a/custom-ops-introduction/add_one.py
+++ b/custom-ops-introduction/add_one.py
@@ -20,7 +20,7 @@ from max.engine import InferenceSession
 from max.graph import Graph, TensorType, ops
 
 if __name__ == "__main__":
-    path = Path(__file__).parent / "operations.mojopkg"
+    mojo_kernels = Path(__file__).parent / "operations"
 
     rows = 5
     columns = 10
@@ -39,16 +39,14 @@ if __name__ == "__main__":
         input_types=[
             TensorType(dtype, shape=[rows, columns]),
         ],
+        custom_extensions=[mojo_kernels],
     )
 
     # Place the graph on a GPU, if available. Fall back to CPU if not.
     device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
-    session = InferenceSession(
-        devices=[device],
-        custom_extensions=path,
-    )
+    session = InferenceSession(devices=[device])
 
     # Compile the graph.
     model = session.load(graph)

--- a/custom-ops-introduction/mandelbrot.py
+++ b/custom-ops-introduction/mandelbrot.py
@@ -45,8 +45,11 @@ def create_mandelbrot_graph(
 ) -> Graph:
     """Configure a graph to run a Mandelbrot kernel."""
     output_dtype = DType.int32
+    mojo_kernels = Path(__file__).parent / "operations"
+
     with Graph(
         "mandelbrot",
+        custom_extensions=[mojo_kernels],
     ) as graph:
         # The custom Mojo operation is referenced by its string name, and we
         # need to provide inputs as a list as well as expected output types.
@@ -68,8 +71,6 @@ def create_mandelbrot_graph(
 
 
 if __name__ == "__main__":
-    path = Path(__file__).parent / "operations.mojopkg"
-
     # Establish Mandelbrot set ranges.
     WIDTH = 60
     HEIGHT = 25
@@ -90,10 +91,8 @@ if __name__ == "__main__":
     device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session that runs the graph on a GPU, if available.
-    session = InferenceSession(
-        devices=[device],
-        custom_extensions=path,
-    )
+    session = InferenceSession(devices=[device])
+
     # Compile the graph.
     model = session.load(graph)
 

--- a/custom-ops-introduction/operations/add_one.mojo
+++ b/custom-ops-introduction/operations/add_one.mojo
@@ -23,7 +23,7 @@ struct AddOne:
     @staticmethod
     fn execute[
         # The kind of device this will be run on: "cpu" or "gpu"
-        target: StringLiteral,
+        target: StaticString,
     ](
         # the first argument is the "output"
         out: OutputTensor,

--- a/custom-ops-introduction/operations/mandelbrot.mojo
+++ b/custom-ops-introduction/operations/mandelbrot.mojo
@@ -28,7 +28,7 @@ struct Mandelbrot:
     @staticmethod
     fn execute[
         # The kind of device this will be run on: "cpu" or "gpu"
-        target: StringLiteral,
+        target: StaticString,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
         out: OutputTensor,

--- a/custom-ops-introduction/operations/vector_addition.mojo
+++ b/custom-ops-introduction/operations/vector_addition.mojo
@@ -17,15 +17,15 @@ import compiler
 from gpu import block_dim, block_idx, thread_idx
 from gpu.host import DeviceContext
 from runtime.asyncrt import DeviceContextPtr
-from tensor import OutputTensor, InputTensor, foreach
+from tensor import InputTensor, ManagedTensorSlice, OutputTensor, foreach
 
 from utils.index import IndexList
 
 
 fn vector_addition_cpu(
-    out: OutputTensor,
-    lhs: InputTensor[type = out.type, rank = out.rank],
-    rhs: InputTensor[type = out.type, rank = out.rank],
+    out: ManagedTensorSlice[mut=True],
+    lhs: ManagedTensorSlice[type = out.type, rank = out.rank],
+    rhs: ManagedTensorSlice[type = out.type, rank = out.rank],
     ctx: DeviceContextPtr,
 ):
     # Warning: This is an extremely inefficient implementation! It's merely an
@@ -37,9 +37,9 @@ fn vector_addition_cpu(
 
 
 fn vector_addition_gpu(
-    out: OutputTensor,
-    lhs: InputTensor[type = out.type, rank = out.rank],
-    rhs: InputTensor[type = out.type, rank = out.rank],
+    out: ManagedTensorSlice[mut=True],
+    lhs: ManagedTensorSlice[type = out.type, rank = out.rank],
+    rhs: ManagedTensorSlice[type = out.type, rank = out.rank],
     ctx: DeviceContextPtr,
 ) raises:
     # Note: The following has not been tuned for any GPU hardware, and is an
@@ -72,7 +72,7 @@ struct VectorAddition:
     @staticmethod
     fn execute[
         # The kind of device this will be run on: "cpu" or "gpu"
-        target: StringLiteral,
+        target: StaticString,
     ](
         # as num_dps_outputs=1, the first argument is the "output"
         out: OutputTensor[rank=1],

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -22,10 +22,9 @@ channels = [
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 
 [tool.pixi.tasks]
-package = "mojo package operations/ -o operations.mojopkg"
-add_one = { cmd = "python add_one.py", depends-on = ["package"] }
-mandelbrot = { cmd = "python mandelbrot.py", depends-on = ["package"] }
-vector_addition = { cmd = "python vector_addition.py", depends-on = ["package"] }
+add_one = "python add_one.py"
+mandelbrot = "python mandelbrot.py"
+vector_addition = "python vector_addition.py"
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031705"
+max = "==25.3.0.dev2025041105"

--- a/custom-ops-introduction/vector_addition.py
+++ b/custom-ops-introduction/vector_addition.py
@@ -20,7 +20,7 @@ from max.engine import InferenceSession
 from max.graph import Graph, TensorType, ops
 
 if __name__ == "__main__":
-    path = Path(__file__).parent / "operations.mojopkg"
+    mojo_kernels = Path(__file__).parent / "operations"
 
     vector_width = 10
     dtype = DType.float32
@@ -32,6 +32,7 @@ if __name__ == "__main__":
             TensorType(dtype, shape=[vector_width]),
             TensorType(dtype, shape=[vector_width]),
         ],
+        custom_extensions=[mojo_kernels],
     ) as graph:
         # Take in the two inputs to the graph.
         lhs, rhs = graph.inputs
@@ -48,10 +49,7 @@ if __name__ == "__main__":
     device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
-    session = InferenceSession(
-        devices=[device],
-        custom_extensions=path,
-    )
+    session = InferenceSession(devices=[device])
 
     # Compile the graph.
     model = session.load(graph)

--- a/custom-ops-matrix-multiplication/benchmarks.mojo
+++ b/custom-ops-matrix-multiplication/benchmarks.mojo
@@ -144,7 +144,7 @@ def matmul():
         var c_dev = _BenchTensor[Output, c_spec](gpu_ctx).rand()
 
         @parameter
-        def bench_matmul_kernel[impl: StringLiteral]():
+        def bench_matmul_kernel[impl: StaticString]():
             @parameter
             @always_inline
             fn bench_gpu(mut bench: Bencher) raises:
@@ -158,7 +158,7 @@ def matmul():
                 bench.iter_custom[kernel_launch](gpu_ctx)
 
             bench.bench_function[bench_gpu](
-                BenchId("gpu", impl), flops, elements
+                BenchId("gpu", String(impl)), flops, elements
             )
 
         bench_matmul_kernel["naive"]()

--- a/custom-ops-matrix-multiplication/matrix_multiplication.py
+++ b/custom-ops-matrix-multiplication/matrix_multiplication.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-import os
 from pathlib import Path
 
 import numpy as np
@@ -36,6 +35,8 @@ def matrix_multiplication(
     a_tensor = Tensor.from_numpy(a).to(device)
     b_tensor = Tensor.from_numpy(b).to(device)
 
+    mojo_kernels = Path(__file__).parent / "operations"
+
     # Configure our simple one-operation graph.
     with Graph(
         "matrix_multiplication_graph",
@@ -43,6 +44,7 @@ def matrix_multiplication(
             TensorType(dtype, shape=a_tensor.shape),
             TensorType(dtype, shape=b_tensor.shape),
         ],
+        custom_extensions=[mojo_kernels],
     ) as graph:
         # Take in the two inputs to the graph.
         a_value, b_value = graph.inputs
@@ -76,8 +78,6 @@ def matrix_multiplication(
 
 
 if __name__ == "__main__":
-    path = Path(__file__).parent / "operations.mojopkg"
-
     M = 256
     K = 256
     N = 256
@@ -86,10 +86,7 @@ if __name__ == "__main__":
     device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
-    session = InferenceSession(
-        devices=[device],
-        custom_extensions=path,
-    )
+    session = InferenceSession(devices=[device])
 
     # Fill the input matrices with random values.
     a = np.random.uniform(size=(M, K)).astype(np.float32)

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -27,4 +27,4 @@ matrix_multiplication = { cmd = "python matrix_multiplication.py", depends-on = 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031705"
+max = "==25.3.0.dev2025041105"

--- a/gpu-functions-mojo/naive_matrix_multiplication.mojo
+++ b/gpu-functions-mojo/naive_matrix_multiplication.mojo
@@ -34,9 +34,6 @@ fn naive_matrix_multiplication[
     n_layout: Layout,
     p_layout: Layout,
 ](
-    i: Int,
-    j: Int,
-    k: Int,
     m: LayoutTensor[float_dtype, m_layout, MutableAnyOrigin],
     n: LayoutTensor[float_dtype, n_layout, MutableAnyOrigin],
     p: LayoutTensor[float_dtype, p_layout, MutableAnyOrigin],
@@ -45,8 +42,12 @@ fn naive_matrix_multiplication[
     row = block_dim.y * block_idx.y + thread_idx.y
     col = block_dim.x * block_idx.x + thread_idx.x
 
-    if row < i and col < k:
-        for j_index in range(j):
+    m_dim = p.dim(0)
+    n_dim = p.dim(1)
+    k_dim = n.dim(0)
+
+    if row < m_dim and col < n_dim:
+        for j_index in range(k_dim):
             p[row, col] += m[row, j_index] * n[j_index, col]
 
 
@@ -110,9 +111,6 @@ def main():
         # are the dimensions of the grid in blocks, and the block dimensions.
         gpu_function(
             gpu_device,
-            I,
-            J,
-            K,
             m_layout_tensor,
             n_layout_tensor,
             p_layout_tensor,

--- a/gpu-functions-mojo/pyproject.toml
+++ b/gpu-functions-mojo/pyproject.toml
@@ -22,10 +22,10 @@ channels = [
 platforms = ["linux-64", "linux-aarch64"]
 
 [tool.pixi.tasks]
-vector_addition = { cmd = "mojo vector_addition.mojo" }
-grayscale = { cmd = "mojo grayscale.mojo" }
-naive_matrix_multiplication = { cmd = "mojo naive_matrix_multiplication.mojo" }
-mandelbrot = { cmd = "mojo mandelbrot.mojo" }
+vector_addition = "mojo vector_addition.mojo"
+grayscale = "mojo grayscale.mojo"
+naive_matrix_multiplication = "mojo naive_matrix_multiplication.mojo"
+mandelbrot = "mojo mandelbrot.mojo"
 
 [tool.pixi.dependencies]
-max = "==25.2.0.dev2025031705"
+max = "==25.3.0.dev2025041105"

--- a/gpu-functions-mojo/vector_addition.mojo
+++ b/gpu-functions-mojo/vector_addition.mojo
@@ -33,14 +33,13 @@ fn vector_addition[
     rhs_layout: Layout,
     out_layout: Layout,
 ](
-    length: Int,
     lhs: LayoutTensor[float_dtype, lhs_layout, MutableAnyOrigin],
     rhs: LayoutTensor[float_dtype, rhs_layout, MutableAnyOrigin],
     out: LayoutTensor[float_dtype, out_layout, MutableAnyOrigin],
 ):
     """The calculation to perform across the vector on the GPU."""
     tid = block_dim.x * block_idx.x + thread_idx.x
-    if tid < length:
+    if tid < out.layout.size():
         out[tid] = lhs[tid] + rhs[tid]
 
 
@@ -95,7 +94,6 @@ def main():
         # are the dimensions of the grid in blocks, and the block dimensions.
         gpu_function(
             gpu_device,
-            VECTOR_WIDTH,
             lhs_layout_tensor,
             rhs_layout_tensor,
             out_layout_tensor,


### PR DESCRIPTION
Significant enhancements have been made to the way that custom operations are loaded as part of a graph since the previous MAX nightly these examples were pinned to. Additionally, StringLiteral is being phased out in favor of StaticString in some of the operation interfaces.

Finally, some unsafe operations that had previously prevented upgrading the MAX version for these examples have been fixed, so it is now possible to move all of them up to track the current nightly. However, I'm still using a pinned nightly for these, to be safe.