### PR TITLE
Update Mojo GPU function examples for using `gpu.host`

### DIFF
--- a/gpu-functions-mojo/grayscale.mojo
+++ b/gpu-functions-mojo/grayscale.mojo
@@ -34,23 +34,23 @@ def main():
         "This examples requires a supported GPU",
     ]()
 
-    var ctx = DeviceContext()
+    ctx = DeviceContext()
 
-    var rgb_buffer = ctx.enqueue_create_buffer[int_dtype](rgb_layout.size())
-    var gray_buffer = ctx.enqueue_create_buffer[int_dtype](gray_layout.size())
+    rgb_buffer = ctx.enqueue_create_buffer[int_dtype](rgb_layout.size())
+    gray_buffer = ctx.enqueue_create_buffer[int_dtype](gray_layout.size())
 
     # Map device buffer to host to initialize values from CPU
     with rgb_buffer.map_to_host() as host_buffer:
-        var rgb_tensor = LayoutTensor[int_dtype, rgb_layout](host_buffer)
         # Fill the image with initial colors.
+        host_rgb_tensor = LayoutTensor[int_dtype, rgb_layout](host_buffer)
         for row in range(HEIGHT):
             for col in range(WIDTH):
-                rgb_tensor[row, col, 0] = row + col
-                rgb_tensor[row, col, 1] = row + col + 20
-                rgb_tensor[row, col, 2] = row + col + 40
+                host_rgb_tensor[row, col, 0] = row + col
+                host_rgb_tensor[row, col, 1] = row + col + 20
+                host_rgb_tensor[row, col, 2] = row + col + 40
 
-    var rgb_tensor = LayoutTensor[int_dtype, rgb_layout](rgb_buffer)
-    var gray_tensor = LayoutTensor[int_dtype, gray_layout](gray_buffer)
+    rgb_tensor = LayoutTensor[int_dtype, rgb_layout](rgb_buffer)
+    gray_tensor = LayoutTensor[int_dtype, gray_layout](gray_buffer)
 
     # The grid is divided up into blocks, making sure there's an extra
     # full block for any remainder. This hasn't been tuned for any specific
@@ -76,8 +76,8 @@ def main():
 
 
 fn color_to_grayscale(
-    rgb_tensor: LayoutTensor[int_dtype, rgb_layout, MutableAnyOrigin],
-    gray_tensor: LayoutTensor[int_dtype, gray_layout, MutableAnyOrigin],
+    rgb_tensor: LayoutTensor[mut=True, int_dtype, rgb_layout],
+    gray_tensor: LayoutTensor[mut=True, int_dtype, gray_layout],
 ):
     """Converting each RGB pixel to grayscale, parallelized across the output tensor on the GPU.
     """
@@ -97,7 +97,7 @@ def print_image(gray_tensor: LayoutTensor[int_dtype, gray_layout]):
     """A helper function to print out the grayscale channel intensities."""
     for row in range(HEIGHT):
         for col in range(WIDTH):
-            var v = gray_tensor[row, col]
+            v = gray_tensor[row, col]
             if v < 100:
                 print(" ", end="")
                 if v < 10:

--- a/gpu-functions-mojo/grayscale.mojo
+++ b/gpu-functions-mojo/grayscale.mojo
@@ -12,130 +12,95 @@
 # ===----------------------------------------------------------------------=== #
 
 
-from gpu.host import Dim
-from gpu.id import block_dim, block_idx, thread_idx
-from math import ceildiv
+from gpu.host import DeviceContext
+from gpu.id import global_idx
 from layout import LayoutTensor, Layout
-from max.driver import (
-    Accelerator,
-    Device,
-    Tensor,
-    accelerator,
-    cpu,
-)
-from sys import has_nvidia_gpu_accelerator
+from math import ceildiv
+from sys import has_nvidia_gpu_accelerator, has_amd_gpu_accelerator
 
-alias channel_dtype = DType.uint8
-alias internal_float_dtype = DType.float32
-alias tensor_rank = 3
+alias WIDTH = 5
+alias HEIGHT = 10
+alias NUM_CHANNELS = 3
+
+alias int_dtype = DType.uint8
+alias float_dtype = DType.float32
+alias rgb_layout = Layout.row_major(HEIGHT, WIDTH, NUM_CHANNELS)
+alias gray_layout = Layout.row_major(HEIGHT, WIDTH)
 
 
-def print_image[h: Int, w: Int](t: Tensor[channel_dtype, 3]):
+def main():
+    constrained[
+        has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator(),
+        "This examples requires a supported GPU",
+    ]()
+
+    var ctx = DeviceContext()
+
+    var rgb_buffer = ctx.enqueue_create_buffer[int_dtype](rgb_layout.size())
+    var gray_buffer = ctx.enqueue_create_buffer[int_dtype](gray_layout.size())
+
+    # Map device buffer to host to initialize values from CPU
+    with rgb_buffer.map_to_host() as host_buffer:
+        var rgb_tensor = LayoutTensor[int_dtype, rgb_layout](host_buffer)
+        # Fill the image with initial colors.
+        for row in range(HEIGHT):
+            for col in range(WIDTH):
+                rgb_tensor[row, col, 0] = row + col
+                rgb_tensor[row, col, 1] = row + col + 20
+                rgb_tensor[row, col, 2] = row + col + 40
+
+    var rgb_tensor = LayoutTensor[int_dtype, rgb_layout](rgb_buffer)
+    var gray_tensor = LayoutTensor[int_dtype, gray_layout](gray_buffer)
+
+    # The grid is divided up into blocks, making sure there's an extra
+    # full block for any remainder. This hasn't been tuned for any specific
+    # GPU.
+    alias BLOCK_SIZE = 16
+    num_col_blocks = ceildiv(WIDTH, BLOCK_SIZE)
+    num_row_blocks = ceildiv(HEIGHT, BLOCK_SIZE)
+
+    # Launch the compiled function on the GPU. The target device is specified
+    # first, followed by all function arguments. The last two named parameters
+    # are the dimensions of the grid in blocks, and the block dimensions.
+    ctx.enqueue_function[color_to_grayscale](
+        rgb_tensor,
+        gray_tensor,
+        grid_dim=(num_col_blocks, num_row_blocks),
+        block_dim=(BLOCK_SIZE, BLOCK_SIZE),
+    )
+
+    with gray_buffer.map_to_host() as host_buffer:
+        host_tensor = LayoutTensor[int_dtype, gray_layout](host_buffer)
+        print("Resulting grayscale image:")
+        print_image(host_tensor)
+
+
+fn color_to_grayscale(
+    rgb_tensor: LayoutTensor[int_dtype, rgb_layout, MutableAnyOrigin],
+    gray_tensor: LayoutTensor[int_dtype, gray_layout, MutableAnyOrigin],
+):
+    """Converting each RGB pixel to grayscale, parallelized across the output tensor on the GPU.
+    """
+    row = global_idx.y
+    col = global_idx.x
+
+    if col < WIDTH and row < HEIGHT:
+        red = rgb_tensor[row, col, 0].cast[float_dtype]()
+        green = rgb_tensor[row, col, 1].cast[float_dtype]()
+        blue = rgb_tensor[row, col, 2].cast[float_dtype]()
+        gray = 0.21 * red + 0.71 * green + 0.07 * blue
+
+        gray_tensor[row, col, 0] = gray.cast[int_dtype]()
+
+
+def print_image(gray_tensor: LayoutTensor[int_dtype, gray_layout]):
     """A helper function to print out the grayscale channel intensities."""
-    out = t.to_layout_tensor()
-    for row in range(h):
-        for col in range(w):
-            var v = out[row, col, 0]
+    for row in range(HEIGHT):
+        for col in range(WIDTH):
+            var v = gray_tensor[row, col]
             if v < 100:
                 print(" ", end="")
                 if v < 10:
                     print(" ", end="")
             print(v, " ", end="")
         print("")
-
-
-fn color_to_grayscale_conversion[
-    image_layout: Layout,
-    out_layout: Layout,
-](
-    width: Int,
-    height: Int,
-    image: LayoutTensor[channel_dtype, image_layout, MutableAnyOrigin],
-    out: LayoutTensor[channel_dtype, out_layout, MutableAnyOrigin],
-):
-    """Converting each RGB pixel to grayscale, parallelized across the output tensor on the GPU.
-    """
-    row = block_dim.y * block_idx.y + thread_idx.y
-    col = block_dim.x * block_idx.x + thread_idx.x
-
-    if col < width and row < height:
-        red = image[row, col, 0].cast[internal_float_dtype]()
-        green = image[row, col, 1].cast[internal_float_dtype]()
-        blue = image[row, col, 2].cast[internal_float_dtype]()
-        gray = 0.21 * red + 0.71 * green + 0.07 * blue
-
-        out[row, col, 0] = gray.cast[channel_dtype]()
-
-
-def main():
-    @parameter
-    if has_nvidia_gpu_accelerator():
-        # Attempt to connect to a compatible GPU. If one is not found, this will
-        # error out and exit.
-        gpu_device = accelerator()
-        host_device = cpu()
-
-        alias IMAGE_WIDTH = 5
-        alias IMAGE_HEIGHT = 10
-        alias NUM_CHANNELS = 3
-
-        # Allocate the input image tensor on the host.
-        rgb_tensor = Tensor[channel_dtype, tensor_rank](
-            (IMAGE_HEIGHT, IMAGE_WIDTH, NUM_CHANNELS), host_device
-        )
-
-        # Fill the image with initial colors.
-        for row in range(IMAGE_HEIGHT):
-            for col in range(IMAGE_WIDTH):
-                rgb_tensor[row, col, 0] = row + col
-                rgb_tensor[row, col, 1] = row + col + 20
-                rgb_tensor[row, col, 2] = row + col + 40
-
-        # Move the image tensor to the accelerator.
-        rgb_tensor = rgb_tensor.move_to(gpu_device)
-
-        # Allocate a tensor on the accelerator to host the grayscale image.
-        gray_tensor = Tensor[channel_dtype, tensor_rank](
-            (IMAGE_HEIGHT, IMAGE_WIDTH, 1), gpu_device
-        )
-
-        rgb_layout_tensor = rgb_tensor.to_layout_tensor()
-        gray_layout_tensor = gray_tensor.to_layout_tensor()
-
-        # Compile the function to run across a grid on the GPU.
-        gpu_function = Accelerator.compile[
-            color_to_grayscale_conversion[
-                rgb_layout_tensor.layout, gray_layout_tensor.layout
-            ]
-        ](gpu_device)
-
-        # The grid is divided up into blocks, making sure there's an extra
-        # full block for any remainder. This hasn't been tuned for any specific
-        # GPU.
-        alias BLOCK_SIZE = 16
-        num_col_blocks = ceildiv(IMAGE_WIDTH, BLOCK_SIZE)
-        num_row_blocks = ceildiv(IMAGE_HEIGHT, BLOCK_SIZE)
-
-        # Launch the compiled function on the GPU. The target device is specified
-        # first, followed by all function arguments. The last two named parameters
-        # are the dimensions of the grid in blocks, and the block dimensions.
-        gpu_function(
-            gpu_device,
-            IMAGE_WIDTH,
-            IMAGE_HEIGHT,
-            rgb_layout_tensor,
-            gray_layout_tensor,
-            grid_dim=Dim(num_col_blocks, num_row_blocks),
-            block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
-        )
-
-        # Move the output tensor back onto the CPU so that we can read the results.
-        gray_tensor = gray_tensor.move_to(host_device)
-
-        print("Resulting grayscale image:")
-        print_image[IMAGE_HEIGHT, IMAGE_WIDTH](gray_tensor)
-    else:
-        print(
-            "These examples require a MAX-compatible NVIDIA GPU and none was"
-            " detected."
-        )

--- a/gpu-functions-mojo/mandelbrot.mojo
+++ b/gpu-functions-mojo/mandelbrot.mojo
@@ -41,11 +41,11 @@ def main():
     ]()
 
     # Get the context for the attached GPU
-    var ctx = DeviceContext()
+    ctx = DeviceContext()
 
     # Allocate a tensor on the target device to hold the resulting set.
-    var dev_buf = ctx.enqueue_create_buffer[int_dtype](layout.size())
-    var out_tensor = LayoutTensor[int_dtype, layout](dev_buf)
+    dev_buf = ctx.enqueue_create_buffer[int_dtype](layout.size())
+    out_tensor = LayoutTensor[int_dtype, layout](dev_buf)
 
     # Compute how many blocks are needed in each dimension to fully cover the grid,
     # rounding up to ensure even partially filled blocks are launched.
@@ -63,30 +63,30 @@ def main():
 
     # Map the output tensor data to CPU so that we can read the results.
     with dev_buf.map_to_host() as host_buf:
-        var host_tensor = LayoutTensor[int_dtype, layout](host_buf)
+        host_tensor = LayoutTensor[int_dtype, layout](host_buf)
         draw_mandelbrot(host_tensor)
 
 
 fn mandelbrot(
-    tensor: LayoutTensor[int_dtype, layout, MutableAnyOrigin],
+    tensor: LayoutTensor[mut=True, int_dtype, layout],
 ):
     """The per-element calculation of iterations to escape in the Mandelbrot set.
     """
     # Obtain the position in the grid from the X, Y thread locations.
-    var row = global_idx.y
-    var col = global_idx.x
+    row = global_idx.y
+    col = global_idx.x
 
     alias SCALE_X = (MAX_X - MIN_X) / GRID_WIDTH
     alias SCALE_Y = (MAX_Y - MIN_Y) / GRID_HEIGHT
 
     # Calculate the complex C corresponding to that grid location.
-    var cx = MIN_X + col * SCALE_X
-    var cy = MIN_Y + row * SCALE_Y
-    var c = ComplexSIMD[float_dtype, 1](cx, cy)
+    cx = MIN_X + col * SCALE_X
+    cy = MIN_Y + row * SCALE_Y
+    c = ComplexSIMD[float_dtype, 1](cx, cy)
 
     # Perform the Mandelbrot iteration loop calculation.
-    var z = ComplexSIMD[float_dtype, 1](0, 0)
-    var iters = Scalar[int_dtype](0)
+    z = ComplexSIMD[float_dtype, 1](0, 0)
+    iters = Scalar[int_dtype](0)
 
     var in_set_mask: Scalar[DType.bool] = True
     for _ in range(MAX_ITERATIONS):
@@ -105,10 +105,10 @@ def draw_mandelbrot(tensor: LayoutTensor[int_dtype, layout]):
     alias sr = StringSlice("....,c8M@jawrpogOQEPGJ")
     for row in range(GRID_HEIGHT):
         for col in range(GRID_WIDTH):
-            var v = tensor[row, col]
+            v = tensor[row, col]
             if v < MAX_ITERATIONS:
-                var idx = Int(v % len(sr))
-                var p = sr[idx]
+                idx = Int(v % len(sr))
+                p = sr[idx]
                 print(p, end="")
             else:
                 print(" ", end="")

--- a/gpu-functions-mojo/mandelbrot.mojo
+++ b/gpu-functions-mojo/mandelbrot.mojo
@@ -11,54 +11,77 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string import StringSlice
 from complex import ComplexSIMD
-from gpu.host import Dim
-from gpu.id import thread_idx, block_dim, block_idx
-from layout import LayoutTensor, Layout
+from gpu import global_idx
+from gpu.host import DeviceContext
+from layout import Layout, LayoutTensor
 from math import ceildiv
-from max.driver import Accelerator, Tensor, accelerator, cpu
-from sys import has_nvidia_gpu_accelerator
+from sys import has_nvidia_gpu_accelerator, has_amd_gpu_accelerator
+
+alias GRID_WIDTH = 60
+alias GRID_HEIGHT = 25
 
 alias float_dtype = DType.float32
 alias int_dtype = DType.int32
 
+alias MIN_X: Scalar[float_dtype] = -2.0
+alias MAX_X: Scalar[float_dtype] = 0.7
+alias MIN_Y: Scalar[float_dtype] = -1.12
+alias MAX_Y: Scalar[float_dtype] = 1.12
 
-def draw_mandelbrot[h: Int, w: Int](t: Tensor[int_dtype, 2], max: Int):
-    """A helper function to visualize the Mandelbrot set in ASCII art."""
-    alias sr = StringSlice("....,c8M@jawrpogOQEPGJ")
-    out = t.to_layout_tensor()
-    for row in range(h):
-        for col in range(w):
-            var v = out[row, col]
-            if v < max:
-                var idx = Int(v % len(sr))
-                var p = sr[idx]
-                print(p, end="")
-            else:
-                print(" ", end="")
-        print("")
+alias MAX_ITERATIONS = 100
+
+alias layout = Layout.row_major(GRID_HEIGHT, GRID_WIDTH)
 
 
-fn mandelbrot[
-    layout: Layout
-](
-    min_x: Scalar[float_dtype],
-    min_y: Scalar[float_dtype],
-    scale_x: Scalar[float_dtype],
-    scale_y: Scalar[float_dtype],
-    max_iterations: Scalar[int_dtype],
-    out: LayoutTensor[int_dtype, layout, MutableAnyOrigin],
+def main():
+    constrained[
+        has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator(),
+        "This examples requires a supported GPU",
+    ]()
+
+    # Get the context for the attached GPU
+    var ctx = DeviceContext()
+
+    # Allocate a tensor on the target device to hold the resulting set.
+    var dev_buf = ctx.enqueue_create_buffer[int_dtype](layout.size())
+    var out_tensor = LayoutTensor[int_dtype, layout](dev_buf)
+
+    # Compute how many blocks are needed in each dimension to fully cover the grid,
+    # rounding up to ensure even partially filled blocks are launched.
+    alias BLOCK_SIZE = 16
+    alias COL_BLOCKS = ceildiv(GRID_WIDTH, BLOCK_SIZE)
+    alias ROW_BLOCKS = ceildiv(GRID_HEIGHT, BLOCK_SIZE)
+
+    # Launch the Mandelbrot kernel on the GPU with a 2D grid of thread blocks.
+    ctx.enqueue_function[mandelbrot](
+        out_tensor,
+        grid_dim=(COL_BLOCKS, ROW_BLOCKS),
+        block_dim=(BLOCK_SIZE, BLOCK_SIZE),
+    )
+    ctx.synchronize()
+
+    # Map the output tensor data to CPU so that we can read the results.
+    with dev_buf.map_to_host() as host_buf:
+        var host_tensor = LayoutTensor[int_dtype, layout](host_buf)
+        draw_mandelbrot(host_tensor)
+
+
+fn mandelbrot(
+    tensor: LayoutTensor[int_dtype, layout, MutableAnyOrigin],
 ):
     """The per-element calculation of iterations to escape in the Mandelbrot set.
     """
     # Obtain the position in the grid from the X, Y thread locations.
-    var row = block_dim.y * block_idx.y + thread_idx.y
-    var col = block_dim.x * block_idx.x + thread_idx.x
+    var row = global_idx.y
+    var col = global_idx.x
+
+    alias SCALE_X = (MAX_X - MIN_X) / GRID_WIDTH
+    alias SCALE_Y = (MAX_Y - MIN_Y) / GRID_HEIGHT
 
     # Calculate the complex C corresponding to that grid location.
-    var cx = min_x + col * scale_x
-    var cy = min_y + row * scale_y
+    var cx = MIN_X + col * SCALE_X
+    var cy = MIN_Y + row * SCALE_Y
     var c = ComplexSIMD[float_dtype, 1](cx, cy)
 
     # Perform the Mandelbrot iteration loop calculation.
@@ -66,7 +89,7 @@ fn mandelbrot[
     var iters = Scalar[int_dtype](0)
 
     var in_set_mask: Scalar[DType.bool] = True
-    for _ in range(max_iterations):
+    for _ in range(MAX_ITERATIONS):
         if not any(in_set_mask):
             break
         in_set_mask = z.squared_norm() <= 4
@@ -74,69 +97,19 @@ fn mandelbrot[
         z = z.squared_add(c)
 
     # Write out the resulting iterations to escape.
-    out[row, col] = iters
+    tensor[row, col] = iters
 
 
-def main():
-    @parameter
-    if has_nvidia_gpu_accelerator():
-        # Attempt to connect to a compatible GPU. If one is not found, this will
-        # error out and exit.
-        gpu_device = accelerator()
-        host_device = cpu()
-
-        # Set the resolution of the Mandelbrot set grid that will be calculated.
-        alias GRID_WIDTH = 60
-        alias GRID_HEIGHT = 25
-
-        # The grid is divided up into blocks, making sure there's an extra
-        # full block for any remainder. This hasn't been tuned for any specific
-        # GPU.
-        alias BLOCK_SIZE = 16
-        num_col_blocks = ceildiv(GRID_WIDTH, BLOCK_SIZE)
-        num_row_blocks = ceildiv(GRID_HEIGHT, BLOCK_SIZE)
-
-        # Set the parameters for the area of the Mandelbrot set we'll be examining.
-        alias MIN_X: Scalar[float_dtype] = -2.0
-        alias MAX_X: Scalar[float_dtype] = 0.7
-        alias MIN_Y: Scalar[float_dtype] = -1.12
-        alias MAX_Y: Scalar[float_dtype] = 1.12
-        alias SCALE_X = (MAX_X - MIN_X) / GRID_WIDTH
-        alias SCALE_Y = (MAX_Y - MIN_Y) / GRID_HEIGHT
-        alias MAX_ITERATIONS = 100
-
-        # Allocate a tensor on the target device to hold the resulting set.
-        out_tensor = Tensor[int_dtype, 2]((GRID_HEIGHT, GRID_WIDTH), gpu_device)
-
-        out_layout_tensor = out_tensor.to_layout_tensor()
-
-        # Compile the function to run across a grid on the GPU.
-        gpu_function = Accelerator.compile[
-            mandelbrot[out_layout_tensor.layout]
-        ](gpu_device)
-
-        # Launch the compiled function on the GPU. The target device is specified
-        # first, followed by all function arguments. The last two named parameters
-        # are the dimensions of the grid in blocks, and the block dimensions.
-        gpu_function(
-            gpu_device,
-            MIN_X,
-            MIN_Y,
-            SCALE_X,
-            SCALE_Y,
-            MAX_ITERATIONS,
-            out_layout_tensor,
-            grid_dim=Dim(num_col_blocks, num_row_blocks),
-            block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
-        )
-
-        # Move the output tensor back onto the CPU so that we can read the results.
-        out_tensor = out_tensor.move_to(host_device)
-
-        # Draw the final Mandelbrot set.
-        draw_mandelbrot[GRID_HEIGHT, GRID_WIDTH](out_tensor, max=MAX_ITERATIONS)
-    else:
-        print(
-            "These examples require a MAX-compatible NVIDIA GPU and none was"
-            " detected."
-        )
+def draw_mandelbrot(tensor: LayoutTensor[int_dtype, layout]):
+    """A helper function to visualize the Mandelbrot set in ASCII art."""
+    alias sr = StringSlice("....,c8M@jawrpogOQEPGJ")
+    for row in range(GRID_HEIGHT):
+        for col in range(GRID_WIDTH):
+            var v = tensor[row, col]
+            if v < MAX_ITERATIONS:
+                var idx = Int(v % len(sr))
+                var p = sr[idx]
+                print(p, end="")
+            else:
+                print(" ", end="")
+        print("")

--- a/gpu-functions-mojo/naive_matrix_multiplication.mojo
+++ b/gpu-functions-mojo/naive_matrix_multiplication.mojo
@@ -12,118 +12,91 @@
 # ===----------------------------------------------------------------------=== #
 
 
-from gpu.host import Dim
-from gpu.id import block_dim, block_idx, thread_idx
-from layout import LayoutTensor, Layout
+from gpu import global_idx
+from gpu.host import DeviceContext
+from layout import Layout, LayoutTensor
 from math import ceildiv
-from max.driver import (
-    Accelerator,
-    Device,
-    Tensor,
-    accelerator,
-    cpu,
-)
-from sys import has_nvidia_gpu_accelerator
+from sys import has_nvidia_gpu_accelerator, has_amd_gpu_accelerator
 
 alias float_dtype = DType.float32
-alias tensor_rank = 2
+
+alias I = 5
+alias J = 4
+alias K = 6
+
+alias m_layout = Layout.row_major(I, J)
+alias n_layout = Layout.row_major(J, K)
+alias p_layout = Layout.row_major(I, K)
 
 
-fn naive_matrix_multiplication[
-    m_layout: Layout,
-    n_layout: Layout,
-    p_layout: Layout,
-](
+def main():
+    constrained[
+        has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator(),
+        "This example requires a supported GPU",
+    ]()
+
+    var ctx = DeviceContext()
+    var m_buffer = ctx.enqueue_create_buffer[float_dtype](m_layout.size())
+    var n_buffer = ctx.enqueue_create_buffer[float_dtype](n_layout.size())
+    var p_buffer = ctx.enqueue_create_buffer[float_dtype](p_layout.size())
+
+    # Map input buffers to host to fill with values from CPU
+    with m_buffer.map_to_host() as host_buffer:
+        var m_tensor = LayoutTensor[float_dtype, m_layout](host_buffer)
+        for m_row in range(I):
+            for m_col in range(J):
+                m_tensor[m_row, m_col] = m_row - m_col
+        print("M matrix:", m_tensor)
+
+    with n_buffer.map_to_host() as host_buffer:
+        var n_tensor = LayoutTensor[float_dtype, n_layout](host_buffer)
+        for n_row in range(J):
+            for n_col in range(K):
+                n_tensor[n_row, n_col] = n_row + n_col
+        print("N matrix:", n_tensor)
+
+    # Wrap device buffers in `LayoutTensor`
+    var m_tensor = LayoutTensor[float_dtype, m_layout](m_buffer)
+    var n_tensor = LayoutTensor[float_dtype, n_layout](n_buffer)
+    var p_tensor = LayoutTensor[float_dtype, p_layout](p_buffer)
+
+    # The grid is divided up into blocks, making sure there's an extra
+    # full block for any remainder. This hasn't been tuned for any specific
+    # GPU.
+    alias BLOCK_SIZE = 16
+    alias num_col_blocks = ceildiv(I, BLOCK_SIZE)
+    alias num_row_blocks = ceildiv(J, BLOCK_SIZE)
+
+    # Launch the compiled function on the GPU. The target device is specified
+    # first, followed by all function arguments. The last two named parameters
+    # are the dimensions of the grid in blocks, and the block dimensions.
+    ctx.enqueue_function[naive_matrix_multiplication](
+        m_tensor,
+        n_tensor,
+        p_tensor,
+        grid_dim=(num_col_blocks, num_row_blocks),
+        block_dim=(BLOCK_SIZE, BLOCK_SIZE),
+    )
+
+    # Move the output tensor back onto the CPU so that we can read the results.
+    with p_buffer.map_to_host() as host_buffer:
+        var host_tensor = LayoutTensor[float_dtype, p_layout](host_buffer)
+        print("Resulting matrix:", host_tensor)
+
+
+fn naive_matrix_multiplication(
     m: LayoutTensor[float_dtype, m_layout, MutableAnyOrigin],
     n: LayoutTensor[float_dtype, n_layout, MutableAnyOrigin],
     p: LayoutTensor[float_dtype, p_layout, MutableAnyOrigin],
 ):
     """Naive matrix multiplication of M_ij x N_jk = P_ik."""
-    row = block_dim.y * block_idx.y + thread_idx.y
-    col = block_dim.x * block_idx.x + thread_idx.x
+    var row = global_idx.y
+    var col = global_idx.x
 
-    m_dim = p.dim(0)
-    n_dim = p.dim(1)
-    k_dim = n.dim(0)
+    var m_dim = p.dim(0)
+    var n_dim = p.dim(1)
+    var k_dim = m.dim(1)
 
     if row < m_dim and col < n_dim:
         for j_index in range(k_dim):
-            p[row, col] += m[row, j_index] * n[j_index, col]
-
-
-def main():
-    @parameter
-    if has_nvidia_gpu_accelerator():
-        # Attempt to connect to a compatible GPU. If one is not found, this will
-        # error out and exit.
-        gpu_device = accelerator()
-        host_device = cpu()
-
-        alias I = 5
-        alias J = 4
-        alias K = 6
-
-        # Allocate the two input matrices on the host.
-        m_tensor = Tensor[float_dtype, tensor_rank]((I, J), host_device)
-        n_tensor = Tensor[float_dtype, tensor_rank]((J, K), host_device)
-
-        # Fill them with initial values.
-        for m_row in range(I):
-            for m_col in range(J):
-                m_tensor[m_row, m_col] = m_row - m_col
-
-        for n_row in range(J):
-            for n_col in range(K):
-                n_tensor[n_row, n_col] = n_row + n_col
-
-        print("M matrix:", m_tensor)
-        print("N matrix:", n_tensor)
-
-        # Move the input matrices to the accelerator.
-        m_tensor = m_tensor.move_to(gpu_device)
-        n_tensor = n_tensor.move_to(gpu_device)
-
-        # Allocate a tensor on the accelerator to host the calculation results.
-        p_tensor = Tensor[float_dtype, tensor_rank]((I, K), gpu_device)
-
-        m_layout_tensor = m_tensor.to_layout_tensor()
-        n_layout_tensor = n_tensor.to_layout_tensor()
-        p_layout_tensor = p_tensor.to_layout_tensor()
-
-        # Compile the function to run across a grid on the GPU.
-        gpu_function = Accelerator.compile[
-            naive_matrix_multiplication[
-                m_layout_tensor.layout,
-                n_layout_tensor.layout,
-                p_layout_tensor.layout,
-            ]
-        ](gpu_device)
-
-        # The grid is divided up into blocks, making sure there's an extra
-        # full block for any remainder. This hasn't been tuned for any specific
-        # GPU.
-        alias BLOCK_SIZE = 16
-        num_col_blocks = ceildiv(I, BLOCK_SIZE)
-        num_row_blocks = ceildiv(J, BLOCK_SIZE)
-
-        # Launch the compiled function on the GPU. The target device is specified
-        # first, followed by all function arguments. The last two named parameters
-        # are the dimensions of the grid in blocks, and the block dimensions.
-        gpu_function(
-            gpu_device,
-            m_layout_tensor,
-            n_layout_tensor,
-            p_layout_tensor,
-            grid_dim=Dim(num_col_blocks, num_row_blocks),
-            block_dim=Dim(BLOCK_SIZE, BLOCK_SIZE),
-        )
-
-        # Move the output tensor back onto the CPU so that we can read the results.
-        p_tensor = p_tensor.move_to(host_device)
-
-        print("Resulting matrix:", p_tensor)
-    else:
-        print(
-            "These examples require a MAX-compatible NVIDIA GPU and none was"
-            " detected."
-        )
+            p[row, col] = p[row, col] + m[row, j_index] * n[j_index, col]

--- a/gpu-functions-mojo/pyproject.toml
+++ b/gpu-functions-mojo/pyproject.toml
@@ -28,4 +28,4 @@ naive_matrix_multiplication = "mojo naive_matrix_multiplication.mojo"
 mandelbrot = "mojo mandelbrot.mojo"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025041105"
+max = "==25.3.0.dev2025042905"

--- a/gpu-functions-mojo/vector_addition.mojo
+++ b/gpu-functions-mojo/vector_addition.mojo
@@ -11,102 +11,60 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from gpu.host import Dim
-from gpu.id import block_dim, block_idx, thread_idx
-from layout import LayoutTensor, Layout
+from gpu import thread_idx
+from gpu.host import DeviceContext
+from layout import Layout, LayoutTensor
 from math import ceildiv
-from max.driver import (
-    Accelerator,
-    Device,
-    Tensor,
-    accelerator,
-    cpu,
-)
-from sys import has_nvidia_gpu_accelerator
+from sys import has_nvidia_gpu_accelerator, has_amd_gpu_accelerator
 
 alias float_dtype = DType.float32
-alias tensor_rank = 1
-
-
-fn vector_addition[
-    lhs_layout: Layout,
-    rhs_layout: Layout,
-    out_layout: Layout,
-](
-    lhs: LayoutTensor[float_dtype, lhs_layout, MutableAnyOrigin],
-    rhs: LayoutTensor[float_dtype, rhs_layout, MutableAnyOrigin],
-    out: LayoutTensor[float_dtype, out_layout, MutableAnyOrigin],
-):
-    """The calculation to perform across the vector on the GPU."""
-    tid = block_dim.x * block_idx.x + thread_idx.x
-    if tid < out.layout.size():
-        out[tid] = lhs[tid] + rhs[tid]
+alias VECTOR_WIDTH = 10
+alias layout = Layout.row_major(VECTOR_WIDTH)
 
 
 def main():
-    @parameter
-    if has_nvidia_gpu_accelerator():
-        # Attempt to connect to a compatible GPU. If one is not found, this will
-        # error out and exit.
-        gpu_device = accelerator()
-        host_device = cpu()
+    constrained[
+        has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator(),
+        "This example requires a supported GPU",
+    ]()
 
-        alias VECTOR_WIDTH = 10
+    # Get context for the attached GPU
+    var ctx = DeviceContext()
 
-        # Allocate the two input tensors on the host.
-        lhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
-        rhs_tensor = Tensor[float_dtype, 1]((VECTOR_WIDTH), host_device)
+    # Allocate data on the GPU address space
+    var lhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
+    var rhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
+    var out_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
 
-        # Fill them with initial values.
-        for i in range(VECTOR_WIDTH):
-            lhs_tensor[i] = 1.25
-            rhs_tensor[i] = 2.5
+    # Fill in values across the entire width
+    _ = lhs_buffer.enqueue_fill(1.25)
+    _ = rhs_buffer.enqueue_fill(2.5)
 
-        # Move the input tensors to the accelerator.
-        lhs_tensor = lhs_tensor.move_to(gpu_device)
-        rhs_tensor = rhs_tensor.move_to(gpu_device)
+    # Wrap the device buffers in tensors
+    var lhs_tensor = LayoutTensor[float_dtype, layout](lhs_buffer)
+    var rhs_tensor = LayoutTensor[float_dtype, layout](rhs_buffer)
+    var out_tensor = LayoutTensor[float_dtype, layout](out_buffer)
 
-        # Allocate a tensor on the accelerator to host the calculation results.
-        out_tensor = Tensor[float_dtype, tensor_rank](
-            (VECTOR_WIDTH), gpu_device
-        )
-        lhs_layout_tensor = lhs_tensor.to_layout_tensor()
-        rhs_layout_tensor = rhs_tensor.to_layout_tensor()
-        out_layout_tensor = out_tensor.to_layout_tensor()
+    # Launch the vector_addition function as a GPU kernel
+    ctx.enqueue_function[vector_addition](
+        lhs_tensor,
+        rhs_tensor,
+        out_tensor,
+        grid_dim=1,
+        block_dim=VECTOR_WIDTH,
+    )
 
-        # Compile the function to run across a grid on the GPU.
-        gpu_function = Accelerator.compile[
-            vector_addition[
-                lhs_layout_tensor.layout,
-                rhs_layout_tensor.layout,
-                out_layout_tensor.layout,
-            ]
-        ](gpu_device)
+    # Map to host so that values can be printed from the CPU
+    with out_buffer.map_to_host() as host_buffer:
+        var host_tensor = LayoutTensor[float_dtype, layout](host_buffer)
+        print("Resulting vector:", host_tensor)
 
-        # The grid is divided up into blocks, making sure there's an extra
-        # full block for any remainder. This hasn't been tuned for any specific
-        # GPU.
-        alias BLOCK_SIZE = 16
-        var num_blocks = ceildiv(VECTOR_WIDTH, BLOCK_SIZE)
 
-        # Launch the compiled function on the GPU. The target device is specified
-        # first, followed by all function arguments. The last two named parameters
-        # are the dimensions of the grid in blocks, and the block dimensions.
-        gpu_function(
-            gpu_device,
-            lhs_layout_tensor,
-            rhs_layout_tensor,
-            out_layout_tensor,
-            grid_dim=Dim(num_blocks),
-            block_dim=Dim(BLOCK_SIZE),
-        )
-
-        # Move the output tensor back onto the CPU so that we can read the results.
-        out_tensor = out_tensor.move_to(host_device)
-
-        print("Resulting vector:", out_tensor)
-    else:
-        print(
-            "These examples require a MAX-compatible NVIDIA GPU and none was"
-            " detected."
-        )
+fn vector_addition(
+    lhs_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
+    rhs_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
+    out_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
+):
+    """The calculation to perform across the vector on the GPU."""
+    var tid = thread_idx.x
+    out_tensor[tid] = lhs_tensor[tid] + rhs_tensor[tid]

--- a/gpu-functions-mojo/vector_addition.mojo
+++ b/gpu-functions-mojo/vector_addition.mojo
@@ -29,21 +29,21 @@ def main():
     ]()
 
     # Get context for the attached GPU
-    var ctx = DeviceContext()
+    ctx = DeviceContext()
 
     # Allocate data on the GPU address space
-    var lhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
-    var rhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
-    var out_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
+    lhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
+    rhs_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
+    out_buffer = ctx.enqueue_create_buffer[float_dtype](VECTOR_WIDTH)
 
     # Fill in values across the entire width
     _ = lhs_buffer.enqueue_fill(1.25)
     _ = rhs_buffer.enqueue_fill(2.5)
 
     # Wrap the device buffers in tensors
-    var lhs_tensor = LayoutTensor[float_dtype, layout](lhs_buffer)
-    var rhs_tensor = LayoutTensor[float_dtype, layout](rhs_buffer)
-    var out_tensor = LayoutTensor[float_dtype, layout](out_buffer)
+    lhs_tensor = LayoutTensor[float_dtype, layout](lhs_buffer)
+    rhs_tensor = LayoutTensor[float_dtype, layout](rhs_buffer)
+    out_tensor = LayoutTensor[float_dtype, layout](out_buffer)
 
     # Launch the vector_addition function as a GPU kernel
     ctx.enqueue_function[vector_addition](
@@ -56,15 +56,15 @@ def main():
 
     # Map to host so that values can be printed from the CPU
     with out_buffer.map_to_host() as host_buffer:
-        var host_tensor = LayoutTensor[float_dtype, layout](host_buffer)
+        host_tensor = LayoutTensor[float_dtype, layout](host_buffer)
         print("Resulting vector:", host_tensor)
 
 
 fn vector_addition(
-    lhs_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
-    rhs_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
-    out_tensor: LayoutTensor[float_dtype, layout, MutableAnyOrigin],
+    lhs_tensor: LayoutTensor[mut=True, float_dtype, layout],
+    rhs_tensor: LayoutTensor[mut=True, float_dtype, layout],
+    out_tensor: LayoutTensor[mut=True, float_dtype, layout],
 ):
     """The calculation to perform across the vector on the GPU."""
-    var tid = thread_idx.x
+    tid = thread_idx.x
     out_tensor[tid] = lhs_tensor[tid] + rhs_tensor[tid]


### PR DESCRIPTION
We migrated our GPU function examples in the public MAX repository to use capabilities provided by `gpu.host`, such as DeviceContext, in order to align our various GPU programming examples around a single function and buffer dispatch interface. This updates the GPU function recipe code and README to follow the new examples and uses the latest MAX nightly.