### PR TITLE
Update custom ops recipes for the 04292025 MAX nightly

### DIFF
--- a/custom-ops-ai-applications/benchmarks.mojo
+++ b/custom-ops-ai-applications/benchmarks.mojo
@@ -95,6 +95,7 @@ fn _static_spec[
         exclusive=True,
         in_lambda=None,
         out_lambda=None,
+        out_compute_lambda=None,
     )
 
 

--- a/custom-ops-ai-applications/fused_attention.py
+++ b/custom-ops-ai-applications/fused_attention.py
@@ -18,7 +18,7 @@ import numpy as np
 from max.driver import CPU, Accelerator, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine.api import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 
 
 def main():
@@ -37,12 +37,21 @@ def main():
         BD = 8
         BN = 16
 
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+
     with Graph(
         "fused_attention",
         input_types=[
-            TensorType(dtype, shape=[N, D]),
-            TensorType(dtype, shape=[N, D]),
-            TensorType(dtype, shape=[N, D]),
+            TensorType(
+                dtype, shape=[N, D], device=DeviceRef.from_device(device)
+            ),
+            TensorType(
+                dtype, shape=[N, D], device=DeviceRef.from_device(device)
+            ),
+            TensorType(
+                dtype, shape=[N, D], device=DeviceRef.from_device(device)
+            ),
         ],
         custom_extensions=[mojo_kernels],
     ) as graph:
@@ -51,12 +60,13 @@ def main():
             name="fused_attention_custom",
             parameters={"N": N, "D": D, "BD": BD, "BN": BN},
             values=[q, k, v],
-            out_types=[TensorType(dtype, shape=[N, D])],
+            out_types=[
+                TensorType(
+                    dtype, shape=[N, D], device=DeviceRef.from_device(device)
+                )
+            ],
         )
         graph.output(*results)
-
-    # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
     session = InferenceSession(devices=[device])

--- a/custom-ops-ai-applications/operations/fused_attention.mojo
+++ b/custom-ops-ai-applications/operations/fused_attention.mojo
@@ -57,7 +57,8 @@ from compiler import register
 from utils.index import IndexList
 from layout import Layout, LayoutTensor, RuntimeLayout, RuntimeTuple
 from layout.tensor_core import TensorCore
-from layout.math import exp, sum, max
+from layout.math import sum, max
+from math import exp
 from gpu.host import DeviceContext
 from gpu.id import block_idx
 from gpu.sync import barrier

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -28,4 +28,4 @@ fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025041105"
+max = "==25.3.0.dev2025042905"

--- a/custom-ops-ai-applications/top_k.py
+++ b/custom-ops-ai-applications/top_k.py
@@ -19,7 +19,7 @@ import numpy as np
 from max.driver import CPU, Accelerator, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine.api import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 from numpy.typing import NDArray
 
 INPUT_TEXT = """
@@ -124,11 +124,20 @@ def main():
     batch_size = len(probabilities)
     K = frequencies.max_next_words
 
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if args.cpu or accelerator_count() == 0 else Accelerator()
+
     # Configure our simple one-operation graph.
     with Graph(
         "top_k_sampler",
         # The dtype and shape of the probabilities being passed in
-        input_types=[TensorType(DType.float32, shape=[batch_size, K])],
+        input_types=[
+            TensorType(
+                DType.float32,
+                shape=[batch_size, K],
+                device=DeviceRef.from_device(device),
+            )
+        ],
         custom_extensions=[mojo_kernels],
     ) as graph:
         # Take the probabilities as a single input to the graph.
@@ -143,15 +152,20 @@ def main():
             values=[probs],
             out_types=[
                 # The output values dtype and shape
-                TensorType(probs.tensor.dtype, probs.tensor.shape),
+                TensorType(
+                    probs.tensor.dtype,
+                    probs.tensor.shape,
+                    device=DeviceRef.from_device(device),
+                ),
                 # The output indices dtype and shape
-                TensorType(DType.int32, probs.tensor.shape),
+                TensorType(
+                    DType.int32,
+                    probs.tensor.shape,
+                    device=DeviceRef.from_device(device),
+                ),
             ],
         )
         graph.output(*results)
-
-    # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if args.cpu or accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
     session = InferenceSession(devices=[device])

--- a/custom-ops-introduction/add_one.py
+++ b/custom-ops-introduction/add_one.py
@@ -17,7 +17,7 @@ import numpy as np
 from max.driver import CPU, Accelerator, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 
 if __name__ == "__main__":
     mojo_kernels = Path(__file__).parent / "operations"
@@ -25,6 +25,9 @@ if __name__ == "__main__":
     rows = 5
     columns = 10
     dtype = DType.float32
+
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Configure our simple one-operation graph.
     graph = Graph(
@@ -34,16 +37,23 @@ if __name__ == "__main__":
         forward=lambda x: ops.custom(
             name="add_one",
             values=[x],
-            out_types=[TensorType(dtype=x.dtype, shape=x.tensor.shape)],
+            out_types=[
+                TensorType(
+                    dtype=x.dtype,
+                    shape=x.tensor.shape,
+                    device=DeviceRef.from_device(device),
+                )
+            ],
         )[0].tensor,
         input_types=[
-            TensorType(dtype, shape=[rows, columns]),
+            TensorType(
+                dtype,
+                shape=[rows, columns],
+                device=DeviceRef.from_device(device),
+            ),
         ],
         custom_extensions=[mojo_kernels],
     )
-
-    # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
     session = InferenceSession(devices=[device])

--- a/custom-ops-introduction/mandelbrot.py
+++ b/custom-ops-introduction/mandelbrot.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from max.driver import CPU, Accelerator, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 
 
 def draw_mandelbrot(tensor: Tensor, width: int, height: int, iterations: int):
@@ -42,6 +42,7 @@ def create_mandelbrot_graph(
     scale_x: float,
     scale_y: float,
     max_iterations: int,
+    device: DeviceRef,
 ) -> Graph:
     """Configure a graph to run a Mandelbrot kernel."""
     output_dtype = DType.int32
@@ -62,7 +63,11 @@ def create_mandelbrot_graph(
                 ops.constant(scale_y, dtype=DType.float32),
                 ops.constant(max_iterations, dtype=DType.int32),
             ],
-            out_types=[TensorType(dtype=output_dtype, shape=[height, width])],
+            out_types=[
+                TensorType(
+                    dtype=output_dtype, shape=[height, width], device=device
+                )
+            ],
         )[0].tensor
 
         # Return the result of the custom operation as the output of the graph.
@@ -80,15 +85,22 @@ if __name__ == "__main__":
     MIN_Y = -1.12
     MAX_Y = 1.12
 
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+
     # Configure our simple graph.
     scale_x = (MAX_X - MIN_X) / WIDTH
     scale_y = (MAX_Y - MIN_Y) / HEIGHT
     graph = create_mandelbrot_graph(
-        WIDTH, HEIGHT, MIN_X, MIN_Y, scale_x, scale_y, MAX_ITERATIONS
+        WIDTH,
+        HEIGHT,
+        MIN_X,
+        MIN_Y,
+        scale_x,
+        scale_y,
+        MAX_ITERATIONS,
+        DeviceRef.from_device(device),
     )
-
-    # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session that runs the graph on a GPU, if available.
     session = InferenceSession(devices=[device])

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -27,4 +27,4 @@ mandelbrot = "python mandelbrot.py"
 vector_addition = "python vector_addition.py"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025041105"
+max = "==25.3.0.dev2025042905"

--- a/custom-ops-introduction/vector_addition.py
+++ b/custom-ops-introduction/vector_addition.py
@@ -17,7 +17,7 @@ import numpy as np
 from max.driver import CPU, Accelerator, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 
 if __name__ == "__main__":
     mojo_kernels = Path(__file__).parent / "operations"
@@ -25,12 +25,23 @@ if __name__ == "__main__":
     vector_width = 10
     dtype = DType.float32
 
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+
     # Configure our simple one-operation graph.
     with Graph(
         "vector_addition",
         input_types=[
-            TensorType(dtype, shape=[vector_width]),
-            TensorType(dtype, shape=[vector_width]),
+            TensorType(
+                dtype,
+                shape=[vector_width],
+                device=DeviceRef.from_device(device),
+            ),
+            TensorType(
+                dtype,
+                shape=[vector_width],
+                device=DeviceRef.from_device(device),
+            ),
         ],
         custom_extensions=[mojo_kernels],
     ) as graph:
@@ -40,13 +51,14 @@ if __name__ == "__main__":
             name="vector_addition",
             values=[lhs, rhs],
             out_types=[
-                TensorType(dtype=lhs.tensor.dtype, shape=lhs.tensor.shape)
+                TensorType(
+                    dtype=lhs.tensor.dtype,
+                    shape=lhs.tensor.shape,
+                    device=DeviceRef.from_device(device),
+                )
             ],
         )[0].tensor
         graph.output(output)
-
-    # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if accelerator_count() == 0 else Accelerator()
 
     # Set up an inference session for running the graph.
     session = InferenceSession(devices=[device])

--- a/custom-ops-matrix-multiplication/benchmarks.mojo
+++ b/custom-ops-matrix-multiplication/benchmarks.mojo
@@ -95,6 +95,7 @@ fn _static_spec[
         exclusive=True,
         in_lambda=None,
         out_lambda=None,
+        out_compute_lambda=None,
     )
 
 

--- a/custom-ops-matrix-multiplication/matrix_multiplication.py
+++ b/custom-ops-matrix-multiplication/matrix_multiplication.py
@@ -17,7 +17,7 @@ import numpy as np
 from max.driver import CPU, Accelerator, Device, Tensor, accelerator_count
 from max.dtype import DType
 from max.engine import InferenceSession
-from max.graph import Graph, TensorType, ops
+from max.graph import DeviceRef, Graph, TensorType, ops
 from numpy.typing import NDArray
 
 
@@ -41,8 +41,16 @@ def matrix_multiplication(
     with Graph(
         "matrix_multiplication_graph",
         input_types=[
-            TensorType(dtype, shape=a_tensor.shape),
-            TensorType(dtype, shape=b_tensor.shape),
+            TensorType(
+                dtype,
+                shape=a_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
+            TensorType(
+                dtype,
+                shape=b_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
         ],
         custom_extensions=[mojo_kernels],
     ) as graph:
@@ -58,6 +66,7 @@ def matrix_multiplication(
                 TensorType(
                     dtype=a_value.tensor.dtype,
                     shape=[a_value.tensor.shape[0], b_value.tensor.shape[1]],
+                    device=DeviceRef.from_device(device),
                 )
             ],
             parameters={"algorithm": algorithm},

--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -935,7 +935,7 @@ struct MatrixMultiplication[algorithm: StaticString]:
                 alias TN = 8
                 alias NUM_THREADS = (BM * BN) // (TM * TN)
                 gpu_ctx.enqueue_function[
-                    block_tiled_matrix_multiplication[
+                    block_tiled_vectorized_matrix_multiplication[
                         out.type,
                         a_layout.layout,
                         b_layout.layout,

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -27,4 +27,4 @@ matrix_multiplication = { cmd = "python matrix_multiplication.py", depends-on = 
 benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025041105"
+max = "==25.3.0.dev2025042905"


### PR DESCRIPTION
`TensorType` now requires a DeviceRef, so this updates all of the custom operation examples to use that and moves forward the pinned MAX nightly to this morning. Additionally, we weren't actually benchmarking the `block_tiled_vectorized_matrix_multiplication` function, so that has been fixed in the matrix multiplication example.