### PR TITLE
Add a template for Mojo custom operation development

### DIFF
--- a/mojo-operation-template/.gitignore
+++ b/mojo-operation-template/.gitignore
@@ -1,0 +1,8 @@
+# pixi environments
+.pixi
+*.egg-info
+# magic environments
+.magic
+.env
+# build products
+operations.mojopkg

--- a/mojo-operation-template/.gitignore
+++ b/mojo-operation-template/.gitignore
@@ -1,5 +1,6 @@
 # pixi environments
 .pixi
+pixi.lock
 *.egg-info
 # magic environments
 .magic

--- a/mojo-operation-template/README.md
+++ b/mojo-operation-template/README.md
@@ -1,0 +1,64 @@
+# A template for Mojo CPU / GPU custom operation development #
+
+Modular's [Mojo](https://docs.modular.com/mojo/manual/) language, combined with
+the [MAX](https://docs.modular.com/max/) framework, provide an elegant
+programming environment for getting the most out of a variety of GPU and CPU
+architectures.
+
+When developing a new computational kernel, it can be helpful to start with
+scaffolding that lets you drop in a reference implementation and hack on it to
+optimize performance. This is an easy-to-initialize template that sets up the
+basics for hacking on a kernel with the ultimate goal of placing it in a
+Python-based model. You can start either through cloning the repository or
+initializing a project using the Magic command-line interface (see later).
+
+## Usage ##
+
+The command-line tool Magic will handle all dependency setup for MAX, and can
+be installed via
+
+```sh
+curl -ssL https://magic.modular.com | bash
+```
+
+Once Magic is installed on your system, a new directory can be created from
+this template using the command
+
+```sh
+magic init [new project directory] --from BradLarson/mojo-operation-template
+```
+
+The template begins with an example of a Mojo kernel, and contains the
+components necessary to run a kernel within a Python computational graph, tests
+to verify its correctness, and rigorous benchmarks to evaluate its performance.
+
+A very basic one-operation graph in Python that contains the custom Mojo
+operation can be run using
+
+```sh
+magic run graph
+```
+
+This will compile the Mojo code for the kernel, place it in a graph, compile
+the graph, and run it.
+
+## Running tests ##
+
+The tests in this project are configured as pytest test cases. To run them, use
+
+```sh
+magic run test
+```
+
+## Benchmarking ##
+
+A series of rigorous performance benchmarks for the kernel in development have
+been configured using the Mojo `benchmark` module. To run them, use the command
+
+```sh
+magic run benchmarks
+```
+
+## License ##
+
+Apache License v2.0 with LLVM Exceptions.

--- a/mojo-operation-template/README.md
+++ b/mojo-operation-template/README.md
@@ -25,12 +25,43 @@ Once Magic is installed on your system, a new directory can be created from
 this template using the command
 
 ```sh
-magic init [new project directory] --from BradLarson/mojo-operation-template
+magic init [new project directory] --from mojo-operation-template
 ```
 
 The template begins with an example of a Mojo kernel, and contains the
 components necessary to run a kernel within a Python computational graph, tests
 to verify its correctness, and rigorous benchmarks to evaluate its performance.
+
+## Running tests ##
+
+There are both Mojo unit tests and `pytest`-based Python unit tests in this
+template. If you're working from pure Mojo code, you can start with the former,
+and can move to the Python-based tests if you'd like to verify an operation
+inside of a Python MAX graph.
+
+To run the Mojo unit tests, use
+
+```sh
+magic run test
+```
+
+To run the `pytest` unit tests, use
+
+```sh
+magic run pytest
+```
+
+## Benchmarking ##
+
+A series of rigorous performance benchmarks for the Mojo kernel in development
+have been configured using the Mojo `benchmark` module. To run them, use the
+command
+
+```sh
+magic run benchmarks
+```
+
+## Running a graph containing this operation ##
 
 A very basic one-operation graph in Python that contains the custom Mojo
 operation can be run using
@@ -40,24 +71,8 @@ magic run graph
 ```
 
 This will compile the Mojo code for the kernel, place it in a graph, compile
-the graph, and run it.
-
-## Running tests ##
-
-The tests in this project are configured as pytest test cases. To run them, use
-
-```sh
-magic run test
-```
-
-## Benchmarking ##
-
-A series of rigorous performance benchmarks for the kernel in development have
-been configured using the Mojo `benchmark` module. To run them, use the command
-
-```sh
-magic run benchmarks
-```
+the graph, and run it. Such a graph is an example of how this operation would
+be used in a larger AI model within the MAX framework.
 
 ## License ##
 

--- a/mojo-operation-template/benchmarks.mojo
+++ b/mojo-operation-template/benchmarks.mojo
@@ -1,0 +1,172 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from benchmark import ThroughputMeasure, BenchId, BenchMetric, Bench, Bencher
+from buffer.dimlist import DimList
+from gpu.host import DeviceContext, DeviceBuffer
+from math import iota
+from max.driver import cpu
+from max.tensor import (
+    ManagedTensorSlice,
+    InputTensor,
+    OutputTensor,
+    StaticTensorSpec,
+    IOSpec,
+    Input,
+    Output,
+    MutableInput,
+)
+from memory import AddressSpace
+from memory import UnsafePointer
+from operations.matrix_multiplication import MatrixMultiplication
+from random import rand
+from runtime.asyncrt import DeviceContextPtr
+from sys import sizeof, has_nvidia_gpu_accelerator
+from utils import IndexList
+
+
+# Wrap a ManagedTensorSlice with a DeviceBuffer which has a lifetime to use
+# Mojo's memory management, and sidestep the Python initialized garbage
+# collected version.
+@value
+struct _BenchTensor[
+    dtype: DType,
+    rank: Int, //,
+    io_spec: IOSpec,
+    static_spec: StaticTensorSpec[dtype, rank],
+]:
+    alias tensor_type = ManagedTensorSlice[
+        io_spec=io_spec, static_spec=static_spec
+    ]
+    alias buffer_type = DeviceBuffer[dtype]
+    alias ptr_type = UnsafePointer[Scalar[dtype]]
+    alias size = Int(static_spec.shape.product())
+
+    var tensor: Self.tensor_type
+    var buffer: Self.buffer_type
+
+    fn __init__(out self, ctx: DeviceContext) raises:
+        self.buffer = ctx.enqueue_create_buffer[dtype](Self.size)
+
+        self.tensor = ManagedTensorSlice[
+            io_spec=io_spec, static_spec=static_spec
+        ](
+            self.buffer.unsafe_ptr(),
+            Self.static_spec.shape.into_index_list[rank](),
+            Self.static_spec.strides.into_index_list[rank](),
+        )
+
+    fn unsafe_ptr(self) -> Self.ptr_type:
+        return self.buffer.unsafe_ptr()
+
+    fn rand(self) raises -> Self:
+        with self.buffer.map_to_host() as host_buffer:
+            rand(host_buffer.unsafe_ptr(), Self.size)
+            return self
+
+    fn iota(self) raises -> Self:
+        with self.buffer.map_to_host() as host_buffer:
+            iota(host_buffer.unsafe_ptr(), Self.size)
+            return self
+
+
+# TODO: Change StaticTensorSpec to use `IndexList` instead of `DimList` in order
+# to determine strides from shape at compile time, and align with
+# RuntimeTensorSpec.
+fn _static_spec[
+    dtype: DType, rank: Int
+](shape: DimList, strides: DimList, out spec: StaticTensorSpec[dtype, rank]):
+    spec = __type_of(spec)(
+        shape=shape,
+        strides=strides,
+        alignment=sizeof[dtype](),
+        address_space=AddressSpace.GENERIC,
+        exclusive=True,
+        in_lambda=None,
+        out_lambda=None,
+        out_compute_lambda=None,
+    )
+
+
+def matmul():
+    alias M = 1028
+    alias K = 1028
+    alias N = 1028
+
+    alias rank = 2
+    alias dtype = DType.float32
+
+    alias FLOPS = M * N * (2 * K - 1)
+
+    alias a_spec = _static_spec[dtype, rank](shape=(M, K), strides=(K, 1))
+    alias b_spec = _static_spec[dtype, rank](shape=(K, N), strides=(N, 1))
+    alias c_spec = _static_spec[dtype, rank](shape=(M, N), strides=(N, 1))
+
+    var cpu_ctx = DeviceContext(api="cpu")
+
+    var a = _BenchTensor[Input, a_spec](cpu_ctx).rand()
+    var b = _BenchTensor[Input, b_spec](cpu_ctx).rand()
+    var c = _BenchTensor[Output, c_spec](cpu_ctx).rand()
+
+    var bench = Bench()
+    var flops = ThroughputMeasure(BenchMetric.flops, FLOPS)
+    var elements = ThroughputMeasure(BenchMetric.elements, M * N)
+
+    @parameter
+    @always_inline
+    fn bench_cpu(mut bencher: Bencher) raises:
+        @parameter
+        @always_inline
+        fn run_bench() raises:
+            MatrixMultiplication["naive"].execute[target="cpu"](
+                c.tensor, a.tensor, b.tensor, cpu_ctx
+            )
+
+        bencher.iter[run_bench]()
+
+    bench.bench_function[bench_cpu](BenchId("cpu", "naive"), flops, elements)
+
+    @parameter
+    if has_nvidia_gpu_accelerator():
+        var gpu_ctx = DeviceContext()
+        var a_dev = _BenchTensor[Input, a_spec](gpu_ctx).rand()
+        var b_dev = _BenchTensor[Input, b_spec](gpu_ctx).rand()
+        var c_dev = _BenchTensor[Output, c_spec](gpu_ctx).rand()
+
+        @parameter
+        def bench_matmul_kernel[impl: StaticString]():
+            @parameter
+            @always_inline
+            fn bench_gpu(mut bench: Bencher) raises:
+                @parameter
+                @always_inline
+                fn kernel_launch(gpu_ctx: DeviceContext) raises:
+                    MatrixMultiplication[impl].execute[target="gpu"](
+                        c_dev.tensor, a_dev.tensor, b_dev.tensor, gpu_ctx
+                    )
+
+                bench.iter_custom[kernel_launch](gpu_ctx)
+
+            bench.bench_function[bench_gpu](
+                BenchId("gpu", String(impl)), flops, elements
+            )
+
+        bench_matmul_kernel["naive"]()
+        bench_matmul_kernel["optimized"]()
+
+    bench.config.verbose_metric_names = False
+    print(bench)
+
+
+def main():
+    matmul()

--- a/mojo-operation-template/benchmarks.mojo
+++ b/mojo-operation-template/benchmarks.mojo
@@ -28,7 +28,7 @@ from max.tensor import (
 )
 from memory import AddressSpace
 from memory import UnsafePointer
-from operations.matrix_multiplication import MatrixMultiplication
+from operations.graph_operation import MatrixMultiplication
 from random import rand
 from runtime.asyncrt import DeviceContextPtr
 from sys import sizeof, has_amd_gpu_accelerator, has_nvidia_gpu_accelerator

--- a/mojo-operation-template/benchmarks.mojo
+++ b/mojo-operation-template/benchmarks.mojo
@@ -31,9 +31,11 @@ from memory import UnsafePointer
 from operations.matrix_multiplication import MatrixMultiplication
 from random import rand
 from runtime.asyncrt import DeviceContextPtr
-from sys import sizeof, has_nvidia_gpu_accelerator
+from sys import sizeof, has_amd_gpu_accelerator, has_nvidia_gpu_accelerator
 from utils import IndexList
 
+# Note: change this to the ID of the GPU you will use.
+alias DEVICE_ID = 0
 
 # Wrap a ManagedTensorSlice with a DeviceBuffer which has a lifetime to use
 # Mojo's memory management, and sidestep the Python initialized garbage
@@ -137,8 +139,8 @@ def matmul():
     bench.bench_function[bench_cpu](BenchId("cpu", "naive"), flops, elements)
 
     @parameter
-    if has_nvidia_gpu_accelerator():
-        var gpu_ctx = DeviceContext()
+    if has_amd_gpu_accelerator() or has_nvidia_gpu_accelerator():
+        var gpu_ctx = DeviceContext(device_id=DEVICE_ID)
         var a_dev = _BenchTensor[Input, a_spec](gpu_ctx).rand()
         var b_dev = _BenchTensor[Input, b_spec](gpu_ctx).rand()
         var c_dev = _BenchTensor[Output, c_spec](gpu_ctx).rand()

--- a/mojo-operation-template/graph.py
+++ b/mojo-operation-template/graph.py
@@ -124,9 +124,7 @@ if __name__ == "__main__":
         print(naive_result.to_numpy())
         print()
 
-        optimized_result = matrix_multiplication(
-            a, b, "optimized", session, device
-        )
+        optimized_result = matrix_multiplication(a, b, "optimized", session, device)
         print("Optimized matrix multiplication:")
         print(optimized_result.to_numpy())
         print()

--- a/mojo-operation-template/graph.py
+++ b/mojo-operation-template/graph.py
@@ -1,0 +1,138 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from pathlib import Path
+
+import numpy as np
+from max.driver import CPU, Accelerator, Device, Tensor, accelerator_count
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from numpy.typing import NDArray
+
+
+def matrix_multiplication(
+    a: NDArray[np.float32],
+    b: NDArray[np.float32],
+    algorithm: str,
+    session: InferenceSession,
+    device: Device,
+) -> Tensor:
+    dtype = DType.float32
+
+    # Create driver tensors from the input arrays, and move them to the
+    # accelerator.
+    a_tensor = Tensor.from_numpy(a).to(device)
+    b_tensor = Tensor.from_numpy(b).to(device)
+
+    mojo_kernels = Path(__file__).parent / "operations"
+
+    # Configure our simple one-operation graph.
+    with Graph(
+        "matrix_multiplication_graph",
+        input_types=[
+            TensorType(
+                dtype,
+                shape=a_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
+            TensorType(
+                dtype,
+                shape=b_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
+        ],
+        custom_extensions=[mojo_kernels],
+    ) as graph:
+        # Take in the two inputs to the graph.
+        a_value, b_value = graph.inputs
+        # The matrix multiplication custom operation takes in two matrices and
+        # produces a result, with the specific algorithm that is used chosen
+        # via compile-time parameterization.
+        output = ops.custom(
+            name="matrix_multiplication",
+            values=[a_value, b_value],
+            out_types=[
+                TensorType(
+                    dtype=a_value.tensor.dtype,
+                    shape=[a_value.tensor.shape[0], b_value.tensor.shape[1]],
+                    device=DeviceRef.from_device(device),
+                )
+            ],
+            parameters={"algorithm": algorithm},
+        )[0].tensor
+        graph.output(output)
+
+    # Compile the graph.
+    print("Compiling...")
+    model = session.load(graph)
+
+    # Perform the calculation on the target device.
+    print("Executing...")
+    result = model.execute(a_tensor, b_tensor)[0]
+
+    # Copy values back to the CPU to be read.
+    assert isinstance(result, Tensor)
+    return result.to(CPU())
+
+
+if __name__ == "__main__":
+    M = 256
+    K = 256
+    N = 256
+
+    # Place the graph on a GPU, if available. Fall back to CPU if not.
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+
+    # Set up an inference session for running the graph.
+    session = InferenceSession(devices=[device])
+
+    # Fill the input matrices with random values.
+    a = np.random.uniform(size=(M, K)).astype(np.float32)
+    b = np.random.uniform(size=(K, N)).astype(np.float32)
+
+    # First, perform the matrix multiplication in NumPy.
+    print("A:")
+    print(a)
+    print()
+
+    print("B:")
+    print(b)
+    print()
+
+    print("Expected result:")
+    print(a @ b)
+    print()
+
+    if accelerator_count() > 0:
+        # Then, test the various versions of matrix multiplication operations.
+        naive_result = matrix_multiplication(a, b, "naive", session, device)
+        print("Naive matrix multiplication:")
+        print(naive_result.to_numpy())
+        print()
+
+        optimized_result = matrix_multiplication(
+            a, b, "optimized", session, device
+        )
+        print("Optimized matrix multiplication:")
+        print(optimized_result.to_numpy())
+        print()
+    else:
+        print(
+            "No MAX-compatible accelerator detected, only running a naive matrix multiplication:"
+        )
+
+        naive_result = matrix_multiplication(a, b, "naive", session, device)
+        print("Naive matrix multiplication:")
+        print(naive_result.to_numpy())
+        print()

--- a/mojo-operation-template/graph.py
+++ b/mojo-operation-template/graph.py
@@ -91,8 +91,11 @@ if __name__ == "__main__":
     K = 256
     N = 256
 
+    # Note: change this to the ID of the GPU you will use.
+    DEVICE_ID = 0
+
     # Place the graph on a GPU, if available. Fall back to CPU if not.
-    device = CPU() if accelerator_count() == 0 else Accelerator()
+    device = CPU() if accelerator_count() == 0 else Accelerator(id=DEVICE_ID)
 
     # Set up an inference session for running the graph.
     session = InferenceSession(devices=[device])

--- a/mojo-operation-template/metadata.yaml
+++ b/mojo-operation-template/metadata.yaml
@@ -15,3 +15,4 @@ tasks:
   - magic run graph
   - magic run benchmarks
   - magic run test
+  - magic run pytest

--- a/mojo-operation-template/metadata.yaml
+++ b/mojo-operation-template/metadata.yaml
@@ -1,0 +1,17 @@
+version: 1.0
+long_title: "A template for working on Mojo CPU / GPU operations"
+short_title: "Mojo Operation Template"
+author: "Brad Larson"
+author_image: "author/bradlarson.jpg"
+author_url: "https://www.linkedin.com/in/brad-larson-3549a5291/"
+github_repo: "https://github.com/modular/max-recipes/tree/main/mojo-operations-template"
+date: "05-05-2025"
+difficulty: "beginner"
+tags:
+  - max-graph
+  - gpu-programming
+
+tasks:
+  - magic run graph
+  - magic run benchmarks
+  - magic run test

--- a/mojo-operation-template/mojo_tests/__init__.mojo
+++ b/mojo-operation-template/mojo_tests/__init__.mojo
@@ -1,0 +1,12 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #

--- a/mojo-operation-template/mojo_tests/test_correctness.mojo
+++ b/mojo-operation-template/mojo_tests/test_correctness.mojo
@@ -15,12 +15,16 @@ from gpu.host import DeviceContext
 from layout.layout_tensor import Layout, LayoutTensor
 from math import ceildiv
 from sys import has_amd_gpu_accelerator, has_nvidia_gpu_accelerator
-from operations.matrix_multiplication import naive_matrix_multiplication
+from operations.matrix_multiplication import (
+    block_tiled_vectorized_matrix_multiplication,
+    naive_matrix_multiplication,
+)
+from testing import assert_almost_equal
 
 alias DEVICE_ID = 0
 
 
-def test_naive_matmul(ctx: DeviceContext) -> None:
+def test_matmul[variant: StaticString](ctx: DeviceContext) -> None:
     alias M = 16
     alias K = 16
     alias N = 16
@@ -28,9 +32,6 @@ def test_naive_matmul(ctx: DeviceContext) -> None:
     alias a_layout = Layout.row_major(M, K)
     alias b_layout = Layout.row_major(K, N)
     alias c_layout = Layout.row_major(M, N)
-
-    alias BM = 32
-    alias BN = 32
 
     alias float_dtype = DType.float32
 
@@ -43,43 +44,77 @@ def test_naive_matmul(ctx: DeviceContext) -> None:
         for a_row in range(M):
             for a_col in range(K):
                 a_tensor[a_row, a_col] = a_row - a_col
-        print("A matrix:", a_tensor)
 
     with b_buffer.map_to_host() as host_buffer:
         var b_tensor = LayoutTensor[float_dtype, b_layout](host_buffer)
         for b_row in range(N):
             for b_col in range(M):
                 b_tensor[b_row, b_col] = b_row + b_col
-        print("B matrix:", b_tensor)
+
+    _ = c_buffer.enqueue_fill(0.0)
 
     var a_tensor = LayoutTensor[float_dtype, a_layout](a_buffer)
     var b_tensor = LayoutTensor[float_dtype, b_layout](b_buffer)
     var c_tensor = LayoutTensor[float_dtype, c_layout](c_buffer)
 
-    ctx.enqueue_function[
-        naive_matrix_multiplication[
-            float_dtype,
-            a_layout,
-            b_layout,
-            c_layout,
-            BM,
-            BN,
-        ]
-    ](
-        a_tensor,
-        b_tensor,
-        c_tensor,
-        grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
-        block_dim=(BN, BM),
-    )
+    @parameter
+    if variant == "naive":
+        alias BM = 32
+        alias BN = 32
+
+        ctx.enqueue_function[
+            naive_matrix_multiplication[
+                float_dtype,
+                a_layout,
+                b_layout,
+                c_layout,
+                BM,
+                BN,
+            ]
+        ](
+            a_tensor,
+            b_tensor,
+            c_tensor,
+            grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+            block_dim=(BN, BM),
+        )
+    elif variant == "optimized":
+        alias BM = 128
+        alias BN = 128
+        alias BK = 8
+        alias TM = 8
+        alias TN = 8
+        alias NUM_THREADS = (BM * BN) // (TM * TN)
+        ctx.enqueue_function[
+            block_tiled_vectorized_matrix_multiplication[
+                float_dtype,
+                a_layout,
+                b_layout,
+                c_layout,
+                BM,
+                BN,
+                BK,
+                TM,
+                TN,
+                NUM_THREADS,
+            ]
+        ](
+            a_tensor,
+            b_tensor,
+            c_tensor,
+            grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+            block_dim=(NUM_THREADS),
+        )
 
     with c_buffer.map_to_host() as host_buffer:
         var host_tensor = LayoutTensor[float_dtype, c_layout](host_buffer)
-        print("Resulting matrix:", host_tensor)
+        assert_almost_equal(host_tensor[0, 0], -1240.0)
+        assert_almost_equal(host_tensor[M - 1, N - 1], 2360.0)
 
 
 def main():
     @parameter
     if has_amd_gpu_accelerator() or has_nvidia_gpu_accelerator():
         var gpu_ctx = DeviceContext(device_id=DEVICE_ID)
-        test_naive_matmul(gpu_ctx)
+        test_matmul["naive"](gpu_ctx)
+        test_matmul["optimized"](gpu_ctx)

--- a/mojo-operation-template/mojo_tests/test_correctness.mojo
+++ b/mojo-operation-template/mojo_tests/test_correctness.mojo
@@ -1,0 +1,85 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from gpu.host import DeviceContext
+from layout.layout_tensor import Layout, LayoutTensor
+from math import ceildiv
+from sys import has_amd_gpu_accelerator, has_nvidia_gpu_accelerator
+from operations.matrix_multiplication import naive_matrix_multiplication
+
+alias DEVICE_ID = 0
+
+
+def test_naive_matmul(ctx: DeviceContext) -> None:
+    alias M = 16
+    alias K = 16
+    alias N = 16
+
+    alias a_layout = Layout.row_major(M, K)
+    alias b_layout = Layout.row_major(K, N)
+    alias c_layout = Layout.row_major(M, N)
+
+    alias BM = 32
+    alias BN = 32
+
+    alias float_dtype = DType.float32
+
+    var a_buffer = ctx.enqueue_create_buffer[float_dtype](a_layout.size())
+    var b_buffer = ctx.enqueue_create_buffer[float_dtype](b_layout.size())
+    var c_buffer = ctx.enqueue_create_buffer[float_dtype](c_layout.size())
+
+    with a_buffer.map_to_host() as host_buffer:
+        var a_tensor = LayoutTensor[float_dtype, a_layout](host_buffer)
+        for a_row in range(M):
+            for a_col in range(K):
+                a_tensor[a_row, a_col] = a_row - a_col
+        print("A matrix:", a_tensor)
+
+    with b_buffer.map_to_host() as host_buffer:
+        var b_tensor = LayoutTensor[float_dtype, b_layout](host_buffer)
+        for b_row in range(N):
+            for b_col in range(M):
+                b_tensor[b_row, b_col] = b_row + b_col
+        print("B matrix:", b_tensor)
+
+    var a_tensor = LayoutTensor[float_dtype, a_layout](a_buffer)
+    var b_tensor = LayoutTensor[float_dtype, b_layout](b_buffer)
+    var c_tensor = LayoutTensor[float_dtype, c_layout](c_buffer)
+
+    ctx.enqueue_function[
+        naive_matrix_multiplication[
+            float_dtype,
+            a_layout,
+            b_layout,
+            c_layout,
+            BM,
+            BN,
+        ]
+    ](
+        a_tensor,
+        b_tensor,
+        c_tensor,
+        grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+        block_dim=(BN, BM),
+    )
+
+    with c_buffer.map_to_host() as host_buffer:
+        var host_tensor = LayoutTensor[float_dtype, c_layout](host_buffer)
+        print("Resulting matrix:", host_tensor)
+
+
+def main():
+    @parameter
+    if has_amd_gpu_accelerator() or has_nvidia_gpu_accelerator():
+        var gpu_ctx = DeviceContext(device_id=DEVICE_ID)
+        test_naive_matmul(gpu_ctx)

--- a/mojo-operation-template/operations/__init__.mojo
+++ b/mojo-operation-template/operations/__init__.mojo
@@ -1,0 +1,12 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #

--- a/mojo-operation-template/operations/graph_operation.mojo
+++ b/mojo-operation-template/operations/graph_operation.mojo
@@ -1,0 +1,128 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import compiler
+from gpu.host import DeviceBuffer
+from math import ceildiv
+from memory import UnsafePointer
+from runtime.asyncrt import DeviceContextPtr
+from tensor import InputTensor, OutputTensor
+from .matrix_multiplication import (
+    block_tiled_vectorized_matrix_multiplication,
+    naive_matrix_multiplication,
+    naive_matrix_multiplication_cpu,
+)
+
+
+@compiler.register("matrix_multiplication")
+struct MatrixMultiplication[algorithm: StaticString]:
+    """
+    The central custom operation that dispatches to multiple different
+    matrix multiplication implementations, depending on target hardware and
+    selected algorithm.
+    """
+
+    @staticmethod
+    fn execute[
+        # The kind of device this will be run on: "cpu" or "gpu"
+        target: StaticString,
+    ](
+        out: OutputTensor[rank=2],
+        a: InputTensor[type = out.type, rank = out.rank],
+        b: InputTensor[type = out.type, rank = out.rank],
+        # the context is needed for some GPU calls
+        ctx: DeviceContextPtr,
+    ) raises:
+        # At graph compilation time, we will know what device we are compiling
+        # this operation for, so we can specialize it for the target hardware.
+        @parameter
+        if target == "gpu":
+            a_layout = a.to_layout_tensor()
+            b_layout = b.to_layout_tensor()
+            out_layout = out.to_layout_tensor()
+
+            M = a_layout.shape[0]()
+            N = b_layout.shape[1]()
+
+            gpu_ctx = ctx.get_device_context()
+
+            # Zero out the memory in the outbound tensor.
+            gpu_ctx.enqueue_memset(
+                DeviceBuffer[out.type](
+                    gpu_ctx,
+                    rebind[UnsafePointer[Scalar[out.type]]](out_layout.ptr),
+                    M * N,
+                    owning=False,
+                ),
+                0,
+            )
+
+            # We support several compile-time variants for the matrix
+            # multiplication calculation:
+            # - "naive": A naive matrix multiplication using LayoutTensors.
+            # - "optimized": Matrix multiplication using a
+            #   further-optimized 2D block tiling strategy.
+            # In each case, the specific matrix multiplication function is
+            # compiled and enqueued to run on the GPU.
+            @parameter
+            if algorithm == "naive":
+                alias BM = 32
+                alias BN = 32
+                gpu_ctx.enqueue_function[
+                    naive_matrix_multiplication[
+                        out.type,
+                        a_layout.layout,
+                        b_layout.layout,
+                        out_layout.layout,
+                        BM,
+                        BN,
+                    ]
+                ](
+                    a_layout,
+                    b_layout,
+                    out_layout,
+                    grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+                    block_dim=(BN, BM),
+                )
+            elif algorithm == "optimized":
+                alias BM = 128
+                alias BN = 128
+                alias BK = 8
+                alias TM = 8
+                alias TN = 8
+                alias NUM_THREADS = (BM * BN) // (TM * TN)
+                gpu_ctx.enqueue_function[
+                    block_tiled_vectorized_matrix_multiplication[
+                        out.type,
+                        a_layout.layout,
+                        b_layout.layout,
+                        out_layout.layout,
+                        BM,
+                        BN,
+                        BK,
+                        TM,
+                        TN,
+                        NUM_THREADS,
+                    ]
+                ](
+                    a_layout,
+                    b_layout,
+                    out_layout,
+                    grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+                    block_dim=(NUM_THREADS),
+                )
+            else:
+                raise Error("No known matmul algorithm:", algorithm)
+
+        else:
+            naive_matrix_multiplication_cpu(out, a, b)

--- a/mojo-operation-template/operations/matrix_multiplication.mojo
+++ b/mojo-operation-template/operations/matrix_multiplication.mojo
@@ -1,0 +1,341 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import compiler
+from gpu import WARP_SIZE, barrier, block_dim, block_idx, thread_idx
+from gpu.host import DeviceBuffer, DeviceContext
+from gpu.memory import async_copy_wait_all
+from layout.layout_tensor import (
+    Layout,
+    LayoutTensor,
+    copy_dram_to_sram,
+    copy_dram_to_sram_async,
+)
+from layout.math import outer_product_acc
+from layout.tensor_builder import LayoutTensorBuild as tb
+from layout.tensor_core import TensorCore
+from math import ceildiv
+from memory import UnsafePointer
+from runtime.asyncrt import DeviceContextPtr
+from sys.info import simdwidthof
+from tensor import InputTensor, ManagedTensorSlice, OutputTensor
+from utils.index import Index
+
+# ===-----------------------------------------------------------------------===#
+# Naive matrix multiplication (CPU)
+# ===-----------------------------------------------------------------------===#
+
+
+fn naive_matrix_multiplication_cpu(
+    out: ManagedTensorSlice,
+    a: ManagedTensorSlice[type = out.type, rank = out.rank],
+    b: ManagedTensorSlice[type = out.type, rank = out.rank],
+):
+    """A naive matrix multiplication used as a fallback on CPU hardware."""
+    var M = a.shape()[0]
+    var N = b.shape()[1]
+    var K = b.shape()[0]
+
+    for row in range(M):
+        for col in range(N):
+            for k in range(K):
+                out[row, col] = out[row, col] + a[row, k] * b[k, col]
+
+
+# ===-----------------------------------------------------------------------===#
+# Naive matrix multiplication (GPU)
+# ===-----------------------------------------------------------------------===#
+
+
+fn naive_matrix_multiplication[
+    dtype: DType,
+    a_layout: Layout,
+    b_layout: Layout,
+    c_layout: Layout,
+    BM: Int,
+    BN: Int,
+](
+    a: LayoutTensor[dtype, a_layout, MutableAnyOrigin],
+    b: LayoutTensor[dtype, b_layout, MutableAnyOrigin],
+    c: LayoutTensor[dtype, c_layout, MutableAnyOrigin],
+):
+    """
+    GEMM kernel that performs matrix multiplication C = A * B.
+
+    Parameters:
+        dtype: The data type of the input and output tensors.
+        a_layout: The layout of the input tensor A.
+        b_layout: The layout of the input tensor B.
+        c_layout: The layout of the output tensor C.
+        BM: The block size in the M dimension.
+        BN: The block size in the N dimension.
+
+    Args:
+        a: The input tensor A.
+        b: The input tensor B.
+        c: The output tensor C.
+
+    This kernel uses a simple for loop structure to compute the matrix
+    multiplication. Each thread computes a single element of the output matrix
+    C by accumulating the dot product of the corresponding row of A and column
+    of B.
+
+    The kernel assumes that the input matrices A and B are compatible for
+    matrix multiplication, i.e., the number of columns in A equals the number
+    of rows in B.
+    """
+
+    var M = a.dim(0)
+    var N = b.dim(1)
+    var K = b.dim(0)
+
+    # Calculate the column and row indices for each thread.
+    var row = block_dim.x * block_idx.x + thread_idx.x
+    var col = block_dim.y * block_idx.y + thread_idx.y
+
+    # Initialize a register to accumulate the result for this thread.
+    var dst_reg: c.element_type = 0
+
+    # Iterate over the K dimension to compute the dot product.
+    if row < M and col < N:
+        for k_index in range(K):
+            # Multiply the elements and accumulate the result.
+            dst_reg = dst_reg + a[row, k_index] * b[k_index, col]
+
+    # Write the final accumulated result to the output matrix.
+    c[row, col] = dst_reg
+
+
+# ===-----------------------------------------------------------------------===#
+# Matrix multiplication with vectorized memory access
+# ===-----------------------------------------------------------------------===#
+
+
+fn block_tiled_vectorized_matrix_multiplication[
+    dtype: DType,
+    a_layout: Layout,
+    b_layout: Layout,
+    c_layout: Layout,
+    BM: Int,
+    BN: Int,
+    BK: Int,
+    TM: Int,
+    TN: Int,
+    NUM_THREADS: Int,
+](
+    a: LayoutTensor[dtype, a_layout, MutableAnyOrigin],
+    b: LayoutTensor[dtype, b_layout, MutableAnyOrigin],
+    c: LayoutTensor[dtype, c_layout, MutableAnyOrigin],
+):
+    """
+    Tiled GEMM kernel that performs matrix multiplication C = A * B with
+    vectorized memory access.
+
+    Parameters:
+        dtype: The data type of the input and output tensors.
+        a_layout: The layout of the input tensor A.
+        b_layout: The layout of the input tensor B.
+        c_layout: The layout of the output tensor C.
+        BM: The block size in the M dimension.
+        BN: The block size in the N dimension.
+        BK: The block size in the K dimension.
+        TM: The tile size in the M dimension.
+        TN: The tile size in the N dimension.
+        NUM_THREADS: The total number of threads per block.
+
+    Args:
+        a: The input tensor A.
+        b: The input tensor B.
+        c: The output tensor C.
+
+    This kernel uses a 2D block tiling strategy to compute the matrix
+    multiplication. Each thread block computes a BM x BN tile of the output
+    matrix C. Within each thread block, threads are further divided into TM x
+    TN tiles to enable thread-level parallelism.
+
+    The kernel loads tiles of A and B into shared memory using vectorized
+    memory access to improve memory bandwidth utilization. It then performs the
+    matrix multiplication using register-level tiling and accumulates the
+    results in registers.
+
+    The kernel assumes that the input matrices A and B are compatible for
+    matrix multiplication, i.e., the number of columns in A equals the number
+    of rows in B.
+    """
+
+    alias simd_width = simdwidthof[dtype]()
+    var partition_col = thread_idx.x % (BN // TN)
+    var partition_row = thread_idx.x // (BN // TN)
+
+
+    # Get the tile of the output matrix C that this thread is responsible
+    # for computing.
+    var dst = c.tile[BM, BN](block_idx.y, block_idx.x).tile[TM, TN](
+        partition_row, partition_col
+    )
+    var dst_vec = dst.vectorize[1, simd_width]()
+
+    # Allocate shared memory for tiles of A and B.
+    # Use column-major layout for A to get the transpose.
+    var a_smem = tb[dtype]().col_major[BM, BK]().shared().alloc()
+    var b_smem = tb[dtype]().row_major[BK, BN]().shared().alloc()
+
+    # Allocate register tiles to store the partial results and operands.
+    var dst_reg = tb[dtype]().row_major[TM, TN]().local().alloc()
+    var dst_reg_vec = dst_reg.vectorize[1, simd_width]()
+    dst_reg_vec.copy_from(dst_vec)
+
+    var a_reg = tb[dtype]().layout[TM]().local().alloc()
+    var b_reg = tb[dtype]().layout[TN]().local().alloc()
+
+    var ntiles = b.dim(0) // BK
+
+    # Iterate over the tiles of A and B in the K dimension.
+    for block in range(ntiles):
+        alias load_a_layout = Layout.row_major(NUM_THREADS // BK, BK)
+        alias load_b_layout = Layout.row_major(BK, NUM_THREADS // BK)
+        var a_tile = a.tile[BM, BK](block_idx.y, block)
+        var b_tile = b.tile[BK, BN](block, block_idx.x)
+
+        # Load the tiles of A and B into shared memory using vectorized
+        # memory access.
+        copy_dram_to_sram_async[thread_layout=load_a_layout](
+            a_smem.vectorize[simd_width, 1](), a_tile.vectorize[simd_width, 1]()
+        )
+        copy_dram_to_sram_async[thread_layout=load_b_layout](
+            b_smem.vectorize[1, simd_width](), b_tile.vectorize[1, simd_width]()
+        )
+
+        async_copy_wait_all()
+        barrier()
+
+        # Iterate over the elements in the K dimension within the tiles.
+        @parameter
+        for k in range(BK):
+            # Load the corresponding tiles from shared memory into registers.
+            var a_tile = a_smem.tile[TM, 1](partition_row, k)
+            var b_tile = b_smem.tile[1, TN](k, partition_col)
+            a_reg.copy_from(a_tile)
+            b_reg.copy_from(b_tile)
+
+            # Perform outer product and accumulate the partial results.
+            outer_product_acc(dst_reg, a_reg, b_reg)
+
+        barrier()
+
+    # Write the final accumulated results to the output matrix.
+    dst_vec.copy_from(dst_reg_vec)
+
+
+@compiler.register("matrix_multiplication")
+struct MatrixMultiplication[algorithm: StaticString]:
+    """
+    The central custom operation that dispatches to multiple different
+    matrix multiplication implementations, depending on target hardware and
+    selected algorithm.
+    """
+
+    @staticmethod
+    fn execute[
+        # The kind of device this will be run on: "cpu" or "gpu"
+        target: StaticString,
+    ](
+        out: OutputTensor[rank=2],
+        a: InputTensor[type = out.type, rank = out.rank],
+        b: InputTensor[type = out.type, rank = out.rank],
+        # the context is needed for some GPU calls
+        ctx: DeviceContextPtr,
+    ) raises:
+        # At graph compilation time, we will know what device we are compiling
+        # this operation for, so we can specialize it for the target hardware.
+        @parameter
+        if target == "gpu":
+            a_layout = a.to_layout_tensor()
+            b_layout = b.to_layout_tensor()
+            out_layout = out.to_layout_tensor()
+
+            M = a_layout.shape[0]()
+            N = b_layout.shape[1]()
+
+            gpu_ctx = ctx.get_device_context()
+
+            # Zero out the memory in the outbound tensor.
+            gpu_ctx.enqueue_memset(
+                DeviceBuffer[out.type](
+                    gpu_ctx,
+                    rebind[UnsafePointer[Scalar[out.type]]](out_layout.ptr),
+                    M * N,
+                    owning=False,
+                ),
+                0,
+            )
+
+            # We support several compile-time variants for the matrix
+            # multiplication calculation:
+            # - "naive": A naive matrix multiplication using LayoutTensors.
+            # - "optimized": Matrix multiplication using a
+            #   further-optimized 2D block tiling strategy.
+            # In each case, the specific matrix multiplication function is
+            # compiled and enqueued to run on the GPU.
+            @parameter
+            if algorithm == "naive":
+                alias BM = 32
+                alias BN = 32
+                gpu_ctx.enqueue_function[
+                    naive_matrix_multiplication[
+                        out.type,
+                        a_layout.layout,
+                        b_layout.layout,
+                        out_layout.layout,
+                        BM,
+                        BN,
+                    ]
+                ](
+                    a_layout,
+                    b_layout,
+                    out_layout,
+                    grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+                    block_dim=(BN, BM),
+                )
+            elif algorithm == "optimized":
+                alias BM = 128
+                alias BN = 128
+                alias BK = 8
+                alias TM = 8
+                alias TN = 8
+                alias NUM_THREADS = (BM * BN) // (TM * TN)
+                gpu_ctx.enqueue_function[
+                    block_tiled_vectorized_matrix_multiplication[
+                        out.type,
+                        a_layout.layout,
+                        b_layout.layout,
+                        out_layout.layout,
+                        BM,
+                        BN,
+                        BK,
+                        TM,
+                        TN,
+                        NUM_THREADS,
+                    ]
+                ](
+                    a_layout,
+                    b_layout,
+                    out_layout,
+                    grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
+                    block_dim=(NUM_THREADS),
+                )
+            else:
+                raise Error("No known matmul algorithm:", algorithm)
+
+        else:
+            naive_matrix_multiplication_cpu(out, a, b)

--- a/mojo-operation-template/pyproject.toml
+++ b/mojo-operation-template/pyproject.toml
@@ -1,0 +1,39 @@
+[project]
+authors = [{ name = "Modular Inc", email = "hello@modular.com" }]
+description = "A template for working on Mojo CPU / GPU operations"
+name = "mojo-operation-template"
+requires-python = ">= 3.9,<3.13"
+version = "0.1.0"
+
+[build-system]
+build-backend = "hatchling.build"
+requires = ["hatchling"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.pixi.project]
+channels = [
+    "conda-forge",
+    "https://conda.modular.com/max-nightly",
+    "https://conda.modular.com/max",
+    "https://repo.prefix.dev/modular-community",
+]
+platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
+
+[tool.pixi.tasks]
+graph = "python graph.py"
+benchmarks = "mojo benchmarks.mojo"
+
+[tool.pixi.feature.test.tasks]
+test = "pytest"
+
+[tool.pixi.feature.test.dependencies]
+pytest = ">=8.3.2, <9"
+
+[tool.pixi.dependencies]
+max = "==25.3.0.dev2025042905"
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+test = { features = ["test"], solve-group = "default" }

--- a/mojo-operation-template/pyproject.toml
+++ b/mojo-operation-template/pyproject.toml
@@ -24,11 +24,12 @@ platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 [tool.pixi.tasks]
 graph = "python graph.py"
 benchmarks = "mojo benchmarks.mojo"
+test = "mojo -I ./operations mojo_tests/test_correctness.mojo"
 
-[tool.pixi.feature.test.tasks]
-test = "pytest"
+[tool.pixi.feature.pytest.tasks]
+pytest = "pytest"
 
-[tool.pixi.feature.test.dependencies]
+[tool.pixi.feature.pytest.dependencies]
 pytest = ">=8.3.2, <9"
 
 [tool.pixi.dependencies]
@@ -36,4 +37,4 @@ max = "==25.3.0.dev2025042905"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }
-test = { features = ["test"], solve-group = "default" }
+pytest = { features = ["pytest"], solve-group = "default" }

--- a/mojo-operation-template/tests/common.py
+++ b/mojo-operation-template/tests/common.py
@@ -1,0 +1,85 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+from max.driver import CPU, Device, Tensor
+from max.dtype import DType
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.engine import InferenceSession
+
+def matrix_multiplication(
+    a: NDArray[np.float32],
+    b: NDArray[np.float32],
+    algorithm: str,
+    session: InferenceSession,
+    device: Device,
+) -> Tensor:
+    dtype = DType.float32
+
+    # Create driver tensors from the input arrays, and move them to the
+    # accelerator.
+    a_tensor = Tensor.from_numpy(a).to(device)
+    b_tensor = Tensor.from_numpy(b).to(device)
+
+    mojo_kernels = Path(__file__).parent.parent / "operations"
+
+    # Configure our simple one-operation graph.
+    with Graph(
+        "matrix_multiplication_graph",
+        input_types=[
+            TensorType(
+                dtype,
+                shape=a_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
+            TensorType(
+                dtype,
+                shape=b_tensor.shape,
+                device=DeviceRef.from_device(device),
+            ),
+        ],
+        custom_extensions=[mojo_kernels],
+    ) as graph:
+        # Take in the two inputs to the graph.
+        a_value, b_value = graph.inputs
+        # The matrix multiplication custom operation takes in two matrices and
+        # produces a result, with the specific algorithm that is used chosen
+        # via compile-time parameterization.
+        output = ops.custom(
+            name="matrix_multiplication",
+            values=[a_value, b_value],
+            out_types=[
+                TensorType(
+                    dtype=a_value.tensor.dtype,
+                    shape=[a_value.tensor.shape[0], b_value.tensor.shape[1]],
+                    device=DeviceRef.from_device(device),
+                )
+            ],
+            parameters={"algorithm": algorithm},
+        )[0].tensor
+        graph.output(output)
+
+    # Compile the graph.
+    print("Compiling...")
+    model = session.load(graph)
+
+    # Perform the calculation on the target device.
+    print("Executing...")
+    result = model.execute(a_tensor, b_tensor)[0]
+
+    # Copy values back to the CPU to be read.
+    assert isinstance(result, Tensor)
+    return result.to(CPU())

--- a/mojo-operation-template/tests/common.py
+++ b/mojo-operation-template/tests/common.py
@@ -20,6 +20,7 @@ from max.dtype import DType
 from max.graph import DeviceRef, Graph, TensorType, ops
 from max.engine import InferenceSession
 
+
 def matrix_multiplication(
     a: NDArray[np.float32],
     b: NDArray[np.float32],

--- a/mojo-operation-template/tests/conftest.py
+++ b/mojo-operation-template/tests/conftest.py
@@ -18,5 +18,8 @@ from max.engine import InferenceSession
 
 @pytest.fixture(scope="session")
 def session() -> InferenceSession:
-    device = CPU() if accelerator_count() == 0 else Accelerator()
+    # Note: change this to the ID of the GPU you will use.
+    DEVICE_ID = 0
+
+    device = CPU() if accelerator_count() == 0 else Accelerator(id=DEVICE_ID)
     return InferenceSession(devices=[device])

--- a/mojo-operation-template/tests/conftest.py
+++ b/mojo-operation-template/tests/conftest.py
@@ -16,6 +16,7 @@ import pytest
 from max.driver import Accelerator, CPU, accelerator_count
 from max.engine import InferenceSession
 
+
 @pytest.fixture(scope="session")
 def session() -> InferenceSession:
     # Note: change this to the ID of the GPU you will use.

--- a/mojo-operation-template/tests/conftest.py
+++ b/mojo-operation-template/tests/conftest.py
@@ -1,0 +1,22 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from pathlib import Path
+import pytest
+from max.driver import Accelerator, CPU, accelerator_count
+from max.engine import InferenceSession
+
+@pytest.fixture(scope="session")
+def session() -> InferenceSession:
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+    return InferenceSession(devices=[device])

--- a/mojo-operation-template/tests/test_correctness.py
+++ b/mojo-operation-template/tests/test_correctness.py
@@ -17,6 +17,7 @@ from max.dtype import DType
 from max.engine import InferenceSession
 from .common import matrix_multiplication
 
+
 def test_naive_matmul(session: InferenceSession) -> None:
     M = 256
     K = 256
@@ -31,3 +32,21 @@ def test_naive_matmul(session: InferenceSession) -> None:
     assert np.all(np.isclose(naive_result.to_numpy(), expected_result))
     assert naive_result.dtype == DType.float32
     assert naive_result.shape == (M, N)
+
+
+def test_optimized_matmul(session: InferenceSession) -> None:
+    M = 256
+    K = 256
+    N = 256
+
+    a = np.random.uniform(size=(M, K)).astype(np.float32)
+    b = np.random.uniform(size=(K, N)).astype(np.float32)
+    expected_result = a @ b
+
+    optimized_result = matrix_multiplication(
+        a, b, "optimized", session, session.devices[0]
+    )
+
+    assert np.all(np.isclose(optimized_result.to_numpy(), expected_result))
+    assert optimized_result.dtype == DType.float32
+    assert optimized_result.shape == (M, N)

--- a/mojo-operation-template/tests/test_correctness.py
+++ b/mojo-operation-template/tests/test_correctness.py
@@ -1,0 +1,34 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import numpy as np
+from max.driver import Accelerator, CPU, accelerator_count
+from max.dtype import DType
+from max.engine import InferenceSession
+from .common import matrix_multiplication
+
+def test_naive_matmul(session: InferenceSession) -> None:
+    M = 256
+    K = 256
+    N = 256
+
+    a = np.random.uniform(size=(M, K)).astype(np.float32)
+    b = np.random.uniform(size=(K, N)).astype(np.float32)
+    expected_result = a @ b
+
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+    naive_result = matrix_multiplication(a, b, "naive", session, device)
+
+    assert np.all(np.isclose(naive_result.to_numpy(), expected_result))
+    assert naive_result.dtype == DType.float32
+    assert naive_result.shape == (M, N)

--- a/mojo-operation-template/tests/test_correctness.py
+++ b/mojo-operation-template/tests/test_correctness.py
@@ -26,8 +26,7 @@ def test_naive_matmul(session: InferenceSession) -> None:
     b = np.random.uniform(size=(K, N)).astype(np.float32)
     expected_result = a @ b
 
-    device = CPU() if accelerator_count() == 0 else Accelerator()
-    naive_result = matrix_multiplication(a, b, "naive", session, device)
+    naive_result = matrix_multiplication(a, b, "naive", session, session.devices[0])
 
     assert np.all(np.isclose(naive_result.to_numpy(), expected_result))
     assert naive_result.dtype == DType.float32


### PR DESCRIPTION
This creates a recipe for a starter template that can be used to modify, benchmark, and test a Mojo custom operation as part of a simple one-element graph.