### PR TITLE
Fix setting variable in mojo-operation-template script

### DIFF
--- a/mojo-operation-template/profile_amd.sh
+++ b/mojo-operation-template/profile_amd.sh
@@ -22,7 +22,6 @@ mojo build "$MOJO_FILE"
 rocprof-compute profile -n "$BINARY_NAME" -- "./${BINARY_NAME}"
 rocprof-compute analyze -q -p "workloads/${BINARY_NAME}/MI300X_A1" > "${BINARY_NAME}.log"
 
-BINARY_NAME="test_correctness"
 echo
 echo "--------------------------------------------------------------------"
 echo "Profile written, open in text editor to view: ./${BINARY_NAME}.log"


### PR DESCRIPTION
Remove assigning to the BINARY_NAME for a second time
