### PR TITLE
Update custom ops recipes for 20250509 nightly

### DIFF
--- a/custom-ops-ai-applications/operations/top_k.mojo
+++ b/custom-ops-ai-applications/operations/top_k.mojo
@@ -28,7 +28,7 @@ from utils.numerics import min_or_neg_inf
 
 @value
 @register_passable("trivial")
-struct TopKElement[T: DType]:
+struct TopKElement[T: DType](Copyable & GreaterThanComparable):
     """Stores the value with it's index."""
 
     var idx: Int32

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -22,10 +22,9 @@ channels = [
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 
 [tool.pixi.tasks]
-package = "mojo package operations/ -o operations.mojopkg"
-top_k = { cmd = "python top_k.py", depends-on = ["package"] }
-fused_attention = { cmd = "python fused_attention.py", depends-on = ["package"] }
-benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
+top_k = "python top_k.py"
+fused_attention = "python fused_attention.py"
+benchmarks = "mojo benchmarks.mojo"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025042905"
+max = "==25.4.0.dev2025050919"

--- a/custom-ops-introduction/mandelbrot.py
+++ b/custom-ops-introduction/mandelbrot.py
@@ -57,11 +57,21 @@ def create_mandelbrot_graph(
         result = ops.custom(
             name="mandelbrot",
             values=[
-                ops.constant(min_x, dtype=DType.float32),
-                ops.constant(min_y, dtype=DType.float32),
-                ops.constant(scale_x, dtype=DType.float32),
-                ops.constant(scale_y, dtype=DType.float32),
-                ops.constant(max_iterations, dtype=DType.int32),
+                ops.constant(
+                    min_x, dtype=DType.float32, device=DeviceRef.CPU()
+                ),
+                ops.constant(
+                    min_y, dtype=DType.float32, device=DeviceRef.CPU()
+                ),
+                ops.constant(
+                    scale_x, dtype=DType.float32, device=DeviceRef.CPU()
+                ),
+                ops.constant(
+                    scale_y, dtype=DType.float32, device=DeviceRef.CPU()
+                ),
+                ops.constant(
+                    max_iterations, dtype=DType.int32, device=DeviceRef.CPU()
+                ),
             ],
             out_types=[
                 TensorType(

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -27,4 +27,4 @@ mandelbrot = "python mandelbrot.py"
 vector_addition = "python vector_addition.py"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025042905"
+max = "==25.4.0.dev2025050919"

--- a/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
+++ b/custom-ops-matrix-multiplication/operations/matrix_multiplication.mojo
@@ -95,9 +95,9 @@ fn naive_matrix_multiplication[
     of rows in B.
     """
 
-    var M = a.dim(0)
-    var N = b.dim(1)
-    var K = b.dim(0)
+    var M = a.dim[0]()
+    var N = b.dim[1]()
+    var K = b.dim[0]()
 
     # Calculate the column and row indices for each thread.
     var row = block_dim.x * block_idx.x + thread_idx.x
@@ -158,9 +158,9 @@ fn coalescing_matrix_multiplication[
     is then stored back to the output matrix.
     """
 
-    var M = a.dim(0)
-    var N = b.dim(1)
-    var K = b.dim(0)
+    var M = a.dim[0]()
+    var N = b.dim[1]()
+    var K = b.dim[0]()
 
     # Calculate the column and row indices for each thread.
     # Have adjacent threads work on the same row to allow for memory coalescing
@@ -242,7 +242,7 @@ fn tiled_matrix_multiplication[
     var dst_reg: c.element_type = 0
 
     # Iterate over tiles of input matrices A and B
-    for block in range(b.dim(0) // BK):
+    for block in range(b.dim[0]() // BK):
         # Define the layout for loading tiles of A and B into shared memory
         alias load_a_layout = Layout.row_major(NUM_THREADS // BK, BK)
         alias load_b_layout = Layout.row_major(BK, NUM_THREADS // BK)
@@ -340,7 +340,7 @@ fn tiled_register_matrix_multiplication[
     dst_reg.copy_from(dst)
 
     # Iterate over the tiles of A and B in the K dimension.
-    for block in range(b.dim(0) // BK):
+    for block in range(b.dim[0]() // BK):
         # Define the layout for loading tiles of A and B into shared
         # memory.
         alias load_a_layout = Layout.row_major(NUM_THREADS // BK, BK)
@@ -447,7 +447,7 @@ fn block_tiled_matrix_multiplication[
     var a_reg = tb[dtype]().layout[TM]().local().alloc()
     var b_reg = tb[dtype]().layout[TN]().local().alloc()
 
-    var ntiles = b.dim(0) // BK
+    var ntiles = b.dim[0]() // BK
 
     for block in range(ntiles):
         alias load_a_layout = Layout.row_major(NUM_THREADS // BK, BK)
@@ -554,7 +554,7 @@ fn block_tiled_vectorized_matrix_multiplication[
     var a_reg = tb[dtype]().layout[TM]().local().alloc()
     var b_reg = tb[dtype]().layout[TN]().local().alloc()
 
-    var ntiles = b.dim(0) // BK
+    var ntiles = b.dim[0]() // BK
 
     # Iterate over the tiles of A and B in the K dimension.
     for block in range(ntiles):

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -22,9 +22,8 @@ channels = [
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 
 [tool.pixi.tasks]
-package = "mojo package operations/ -o operations.mojopkg"
-matrix_multiplication = { cmd = "python matrix_multiplication.py", depends-on = ["package"] }
-benchmarks = { cmd = "mojo benchmarks.mojo", depends-on = ["package"] }
+matrix_multiplication = "python matrix_multiplication.py"
+benchmarks = "mojo benchmarks.mojo"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025042905"
+max = "==25.4.0.dev2025050919"


### PR DESCRIPTION
In addition to updating the custom ops recipes for the latest nightly, this also removes a no-longer-needed operation packaging step that was confusing the graph compiler.