### PR TITLE
Remove unused channels, rearrange to put conda-forge first

### DIFF
--- a/ai-weather-agent/backend/pyproject.toml
+++ b/ai-weather-agent/backend/pyproject.toml
@@ -27,10 +27,8 @@ packages = ["src"]
 
 [tool.pixi.project]
 channels = [
-    "https://conda.modular.com/max-nightly",
     "conda-forge",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
+    "https://conda.modular.com/max-nightly",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/ai-weather-agent/pixi.toml
+++ b/ai-weather-agent/pixi.toml
@@ -1,10 +1,8 @@
 [project]
 authors = ["Modular <hello@modular.com>"]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
     "conda-forge",
-    "https://repo.prefix.dev/modular-community",
+    "https://conda.modular.com/max-nightly",
 ]
 description = "Add a short description here"
 name = "frontend"

--- a/autodoc-repo-chat-agent/pyproject.toml
+++ b/autodoc-repo-chat-agent/pyproject.toml
@@ -27,10 +27,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-  "https://conda.modular.com/max-nightly",
-  "https://conda.modular.com/max",
-  "https://repo.prefix.dev/modular-community",
   "conda-forge",
+  "https://conda.modular.com/max-nightly",
 ]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 

--- a/code-execution-sandbox-agent-with-e2b/pyproject.toml
+++ b/code-execution-sandbox-agent-with-e2b/pyproject.toml
@@ -19,10 +19,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
     "conda-forge",
+    "https://conda.modular.com/max-nightly",
 ]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 

--- a/custom-ops-ai-applications/pyproject.toml
+++ b/custom-ops-ai-applications/pyproject.toml
@@ -16,8 +16,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/custom-ops-introduction/pyproject.toml
+++ b/custom-ops-introduction/pyproject.toml
@@ -16,8 +16,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/custom-ops-matrix-multiplication/pyproject.toml
+++ b/custom-ops-matrix-multiplication/pyproject.toml
@@ -16,8 +16,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/deepseek-qwen-autogen-agent/pyproject.toml
+++ b/deepseek-qwen-autogen-agent/pyproject.toml
@@ -16,7 +16,7 @@ requires = ["hatchling"]
 packages = ["."]
 
 [tool.pixi.project]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 
 [tool.pixi.pypi-dependencies]

--- a/gpu-functions-mojo/pyproject.toml
+++ b/gpu-functions-mojo/pyproject.toml
@@ -16,8 +16,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "linux-aarch64"]
 

--- a/max-offline-inference/pyproject.toml
+++ b/max-offline-inference/pyproject.toml
@@ -15,10 +15,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
     "conda-forge",
+    "https://conda.modular.com/max-nightly",
 ]
 
 platforms = ["osx-arm64", "linux-aarch64", "linux-64"]

--- a/max-serve-anythingllm/pyproject.toml
+++ b/max-serve-anythingllm/pyproject.toml
@@ -14,10 +14,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
     "conda-forge",
+    "https://conda.modular.com/max-nightly",
 ]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 

--- a/max-serve-continuous-chat/pyproject.toml
+++ b/max-serve-continuous-chat/pyproject.toml
@@ -25,8 +25,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/max-serve-multimodal-structured-output/pyproject.toml
+++ b/max-serve-multimodal-structured-output/pyproject.toml
@@ -16,7 +16,7 @@ requires = ["hatchling"]
 packages = ["."]
 
 [tool.pixi.project]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
 platforms = ["linux-64", "linux-aarch64"]
 
 [tool.pixi.pypi-dependencies]

--- a/max-serve-open-webui/pyproject.toml
+++ b/max-serve-open-webui/pyproject.toml
@@ -18,10 +18,8 @@ packages = ["."]
 [tool.pixi.project]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
     "conda-forge",
+    "https://conda.modular.com/max-nightly",
 ]
 
 [tool.pixi.pypi-dependencies]

--- a/max-serve-openai-embeddings/pyproject.toml
+++ b/max-serve-openai-embeddings/pyproject.toml
@@ -19,10 +19,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-    "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
     "conda-forge",
+    "https://conda.modular.com/max-nightly",
 ]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 

--- a/max-serve-openai-function-calling/pyproject.toml
+++ b/max-serve-openai-function-calling/pyproject.toml
@@ -24,8 +24,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/mojo-operation-template/pyproject.toml
+++ b/mojo-operation-template/pyproject.toml
@@ -16,8 +16,6 @@ packages = ["."]
 channels = [
     "conda-forge",
     "https://conda.modular.com/max-nightly",
-    "https://conda.modular.com/max",
-    "https://repo.prefix.dev/modular-community",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 

--- a/multimodal-rag-with-colpali-llamavision-reranker/pyproject.toml
+++ b/multimodal-rag-with-colpali-llamavision-reranker/pyproject.toml
@@ -16,7 +16,7 @@ requires = ["hatchling"]
 packages = ["."]
 
 [tool.pixi.project]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
 platforms = ["linux-64", "linux-aarch64"]
 
 [tool.pixi.pypi-dependencies]


### PR DESCRIPTION
Generally, we don't want to include channels we don't need. Our `max-nightly` channel is a superset of `max`, so we don't need both, and we don't use anything from the community channel (AFAICT).

Additionally, we should generally put conda-forge first, as this helps with solve times since most dependencies will come from there.