### PR TITLE
Remove redundant `magic run`s

### DIFF
--- a/autodoc-repo-chat-agent/pyproject.toml
+++ b/autodoc-repo-chat-agent/pyproject.toml
@@ -39,6 +39,6 @@ autodoc_repo_chat_agent = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path Qwen/Qwen2.5-7B-Instruct-1M --max-batch-size 100 --enable-prefix-caching"
-agent = "TOKENIZERS_PARALLELISM=false magic run python main.py"
+agent = "TOKENIZERS_PARALLELISM=false python main.py"
 clean = "rm -rf ./docs repo_content.json || true"
 tests = "echo 'test passed'"

--- a/code-execution-sandbox-agent-with-e2b/pyproject.toml
+++ b/code-execution-sandbox-agent-with-e2b/pyproject.toml
@@ -31,6 +31,6 @@ code_execution_sandbox_agent_with_e2b = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --enable-structured-output"
-hello = "magic run python hello.py"
-agent = "magic run python agent.py"
+hello = "python hello.py"
+agent = "python agent.py"
 tests = "echo 'test passed'"

--- a/deepseek-qwen-autogen-agent/pyproject.toml
+++ b/deepseek-qwen-autogen-agent/pyproject.toml
@@ -24,6 +24,6 @@ deepseek_qwen_autogen_agent = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-7B --max-length 16384 --max-batch-size 1"
-chat_agent = "magic run python chat_agent.py"
-screenplay_agents = "magic run python screenplay_agents.py"
+chat_agent = "python chat_agent.py"
+screenplay_agents = "python screenplay_agents.py"
 tests = "echo 'test passed'"

--- a/max-serve-multimodal-structured-output/pyproject.toml
+++ b/max-serve-multimodal-structured-output/pyproject.toml
@@ -24,7 +24,7 @@ max_serve_multimodal_structured_output = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path meta-llama/Llama-3.2-11B-Vision-Instruct --max-length=1000 --max-batch-size=1 --enable-structured-output"
-main = "magic run python main.py"
+main = "python main.py"
 tests = "echo 'test passed'"
 
 [tool.pixi.dependencies]

--- a/max-serve-openai-embeddings/pyproject.toml
+++ b/max-serve-openai-embeddings/pyproject.toml
@@ -31,7 +31,7 @@ max_embeddings = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8000 max-pipelines serve --model-path sentence-transformers/all-mpnet-base-v2"
-main = "magic run python main.py"
+main = "python main.py"
 tests = "bash wait_and_run.sh"
 
 [tool.pixi.dependencies]

--- a/max-serve-openai-function-calling/pyproject.toml
+++ b/max-serve-openai-function-calling/pyproject.toml
@@ -34,9 +34,9 @@ max_serve_openai_function_calling = { path = ".", editable = true }
 
 [tool.pixi.tasks]
 server = "MAX_SERVE_PORT=8077 max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length=2048"
-single_function_call = "magic run python single_function_call.py"
-multi_function_calls = "magic run python multi_function_calls.py"
-app = "magic run python app.py"
+single_function_call = "python single_function_call.py"
+multi_function_calls = "python multi_function_calls.py"
+app = "python app.py"
 tests = "echo 'test passed'"
 
 [tool.pixi.dependencies]


### PR DESCRIPTION
At best, these are just extra indirections, at worst this is a massive performance sink. If you're running these with `pixi`, you effectively get `pixi run magic run python ...` which can end up creating two different venvs. Regardless, these don't do anything extra, so just remove them.