### PR TITLE
Rename max-pipelines to max

### DIFF
--- a/ai-weather-agent/Procfile
+++ b/ai-weather-agent/Procfile
@@ -1,4 +1,4 @@
-max-serve-llm: MAX_SERVE_PORT=8010 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 2048
-max-serve-embedding: MAX_SERVE_PORT=7999 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max-pipelines serve --model-path sentence-transformers/all-mpnet-base-v2
+max-serve-llm: MAX_SERVE_PORT=8010 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 2048
+max-serve-embedding: MAX_SERVE_PORT=7999 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max serve --model-path sentence-transformers/all-mpnet-base-v2
 backend: cd backend && magic run backend
 frontend: cd frontend && magic run frontend

--- a/ai-weather-agent/Procfile.clean
+++ b/ai-weather-agent/Procfile.clean
@@ -1,3 +1,3 @@
-cleanup: pkill -f "max-pipelines serve" || true && pkill -f "magic run backend" || true && pkill -f "magic run frontend" || true
+cleanup: pkill -f "max serve" || true && pkill -f "magic run backend" || true && pkill -f "magic run frontend" || true
 gpu-cleanup: command -v nvidia-smi >/dev/null && nvidia-smi pmon -c 1 | grep python | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
 port-cleanup: lsof -ti:7999,8001,8010,3000 | xargs -r kill -9 2>/dev/null || true

--- a/code-execution-sandbox-agent-with-e2b/pyproject.toml
+++ b/code-execution-sandbox-agent-with-e2b/pyproject.toml
@@ -28,7 +28,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 code_execution_sandbox_agent_with_e2b = { path = ".", editable = true }
 
 [tool.pixi.tasks]
-server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --enable-structured-output"
+server = "MAX_SERVE_PORT=8010 max serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --enable-structured-output"
 hello = "python hello.py"
 agent = "python agent.py"
 tests = "echo 'test passed'"

--- a/deepseek-qwen-autogen-agent/pyproject.toml
+++ b/deepseek-qwen-autogen-agent/pyproject.toml
@@ -23,7 +23,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 deepseek_qwen_autogen_agent = { path = ".", editable = true }
 
 [tool.pixi.tasks]
-server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-7B --max-length 16384 --max-batch-size 1"
+server = "MAX_SERVE_PORT=8010 max serve --model-path deepseek-ai/DeepSeek-R1-Distill-Qwen-7B --max-length 16384 --max-batch-size 1"
 chat_agent = "python chat_agent.py"
 screenplay_agents = "python screenplay_agents.py"
 tests = "echo 'test passed'"

--- a/max-serve-anythingllm/pyproject.toml
+++ b/max-serve-anythingllm/pyproject.toml
@@ -34,9 +34,9 @@ UI_CONTAINER_NAME = "anythingllm-max"
 [tool.pixi.tasks]
 app = "python main.py llm ui --pre setup --post clean"
 setup = "python setup.py"
-llm = "max-pipelines serve  --max-length=$MAX_CONTEXT_LENGTH --max-batch-size=$MAX_BATCH_SIZE --model-path=modularai/Llama-3.1-8B-Instruct-GGUF"
+llm = "max serve  --max-length=$MAX_CONTEXT_LENGTH --max-batch-size=$MAX_BATCH_SIZE --model-path=modularai/Llama-3.1-8B-Instruct-GGUF"
 ui = "docker run -p $UI_PORT:3001 --name $UI_CONTAINER_NAME --cap-add SYS_ADMIN -v $UI_STORAGE_LOCATION:/app/server/storage -v $UI_STORAGE_LOCATION/.env:/app/server/.env -e STORAGE_DIR=\"/app/server/storage\" mintplexlabs/anythingllm"
-clean = "pkill -f \"max-pipelines serve\" || true && lsof -ti:$MAX_SERVE_PORT,$UI_PORT | xargs -r kill -9 2>/dev/null || true && docker rm -f $UI_CONTAINER_NAME 2>/dev/null || true"
+clean = "pkill -f \"max serve\" || true && lsof -ti:$MAX_SERVE_PORT,$UI_PORT | xargs -r kill -9 2>/dev/null || true && docker rm -f $UI_CONTAINER_NAME 2>/dev/null || true"
 tests = "echo 'test passed'"
 
 [tool.pixi.dependencies]

--- a/max-serve-continuous-chat/Procfile
+++ b/max-serve-continuous-chat/Procfile
@@ -1,2 +1,2 @@
-llm: MAX_SERVE_PORT=8000 HUGGING_FACE_HUB_TOKEN=$(cat .env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) && max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 4096
+llm: MAX_SERVE_PORT=8000 HUGGING_FACE_HUB_TOKEN=$(cat .env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) && max serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 4096
 ui: TOKENIZERS_PARALLELISM=false PORT=7860 magic run python ui.py

--- a/max-serve-continuous-chat/Procfile.clean
+++ b/max-serve-continuous-chat/Procfile.clean
@@ -1,3 +1,3 @@
-cleanup: pkill -f "max-pipelines serve" || true && pkill -f "magic run python ui.py" || true
+cleanup: pkill -f "max serve" || true && pkill -f "magic run python ui.py" || true
 gpu-cleanup: command -v nvidia-smi >/dev/null && nvidia-smi pmon -c 1 | grep python | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
 port-cleanup: lsof -ti:8000,7860 | xargs -r kill -9 2>/dev/null || true

--- a/max-serve-continuous-chat/README.md
+++ b/max-serve-continuous-chat/README.md
@@ -340,7 +340,7 @@ You can explore various configuration options by running:
 
 ```bash
 magic global install -u max-pipelines
-max-pipelines serve --help
+max serve --help
 ```
 
 On the serving side, make sure to check out the [benchmarking tutorial](https://docs.modular.com/max/tutorials/benchmark-max-serve)

--- a/max-serve-multimodal-structured-output/README.md
+++ b/max-serve-multimodal-structured-output/README.md
@@ -173,7 +173,7 @@ To enable structured output in MAX Serve, simply include `--enable-structured-ou
 To see other options, make sure to check out the help:
 
 ```bash
-max-pipelines serve --help
+max serve --help
 ```
 
 ## Conclusion

--- a/max-serve-multimodal-structured-output/pyproject.toml
+++ b/max-serve-multimodal-structured-output/pyproject.toml
@@ -23,7 +23,7 @@ platforms = ["linux-64", "linux-aarch64"]
 max_serve_multimodal_structured_output = { path = ".", editable = true }
 
 [tool.pixi.tasks]
-server = "MAX_SERVE_PORT=8010 max-pipelines serve --model-path meta-llama/Llama-3.2-11B-Vision-Instruct --max-length=1000 --max-batch-size=1 --enable-structured-output"
+server = "MAX_SERVE_PORT=8010 max serve --model-path meta-llama/Llama-3.2-11B-Vision-Instruct --max-length=1000 --max-batch-size=1 --enable-structured-output"
 main = "python main.py"
 tests = "echo 'test passed'"
 

--- a/max-serve-open-webui/Procfile.clean
+++ b/max-serve-open-webui/Procfile.clean
@@ -1,2 +1,2 @@
-cleanup: pkill -f "max-pipelines serve" || true && pkill -f "open-webui serve" || true
+cleanup: pkill -f "max serve" || true && pkill -f "open-webui serve" || true
 port-cleanup: lsof -ti:8000,7860 | xargs -r kill -9 2>/dev/null || true

--- a/max-serve-open-webui/pyproject.toml
+++ b/max-serve-open-webui/pyproject.toml
@@ -48,7 +48,7 @@ ui = ["open-webui>=0.5.10,<0.6.0"]
 ### Tasks
 [tool.pixi.feature.max.tasks]
 set-env = "source .env 2>/dev/null || true"
-max = "max-pipelines serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 16384"
+max = "max serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 16384"
 
 ### Dependencies
 [tool.pixi.feature.max.dependencies]

--- a/multimodal-rag-with-colpali-llamavision-reranker/Procfile
+++ b/multimodal-rag-with-colpali-llamavision-reranker/Procfile
@@ -1,3 +1,3 @@
-llm-server: MAX_SERVE_PORT=8010 max-pipelines serve --model-path meta-llama/Llama-3.2-11B-Vision-Instruct --max-length 2048 --max-batch-size 1
+llm-server: MAX_SERVE_PORT=8010 max serve --model-path meta-llama/Llama-3.2-11B-Vision-Instruct --max-length 2048 --max-batch-size 1
 qdrant-server: docker run -p 6333:6333 -p 6334:6334 -v "$(pwd)/qdrant_storage:/qdrant/storage:z" qdrant/qdrant
 app: magic run python app.py

--- a/multimodal-rag-with-colpali-llamavision-reranker/Procfile.clean
+++ b/multimodal-rag-with-colpali-llamavision-reranker/Procfile.clean
@@ -1,4 +1,4 @@
-cleanup: pkill -f "max-pipelines serve" || true && pkill -f "docker run -p 6333:6333 -p 6334:6334 -v $(pwd)/qdrant_storage:/qdrant/storage:z qdrant/qdrant" || true
+cleanup: pkill -f "max serve" || true && pkill -f "docker run -p 6333:6333 -p 6334:6334 -v $(pwd)/qdrant_storage:/qdrant/storage:z qdrant/qdrant" || true
 gpu-cleanup: command -v nvidia-smi >/dev/null && nvidia-smi pmon -c 1 | grep python | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
 port-cleanup: lsof -ti:8010,6333,6334,7860 | xargs -r kill -9 2>/dev/null || true
 qdrat-cleanup: rm -r qdrant_storage 2>/dev/null || true


### PR DESCRIPTION
As of 25.3 `max-pipelines` is deprecated. I plan to remove this alias in 25.4.