### PR TITLE
Update Mojo operation template for Pixi and the latest MAX nightly

### DIFF
--- a/mojo-operation-template/README.md
+++ b/mojo-operation-template/README.md
@@ -9,28 +9,38 @@ When developing a new computational kernel, it can be helpful to start with
 scaffolding that lets you drop in a reference implementation and hack on it to
 optimize performance. This is an easy-to-initialize template that sets up the
 basics for hacking on a kernel with the ultimate goal of placing it in a
-Python-based model. You can start either through cloning the repository or
-initializing a project using the Magic command-line interface (see later).
-
-## Usage ##
-
-The command-line tool Magic will handle all dependency setup for MAX, and can
-be installed via
-
-```sh
-curl -ssL https://magic.modular.com | bash
-```
-
-Once Magic is installed on your system, a new directory can be created from
-this template using the command
-
-```sh
-magic init [new project directory] --from mojo-operation-template
-```
+Python-based model.
 
 The template begins with an example of a Mojo kernel, and contains the
 components necessary to run a kernel within a Python computational graph, tests
 to verify its correctness, and rigorous benchmarks to evaluate its performance.
+
+We recommend using the [`Pixi`](https://pixi.sh/latest/) environment manager,
+which simplifies the installation of dependencies and the overall MAX and Mojo
+development experience.
+
+## Setup
+
+1. Make sure your system includes a [compatible
+GPU](https://docs.modular.com/max/faq/#gpu-requirements).
+
+2. If you don't have [`pixi`](https://pixi.sh/latest/), install it:
+
+    ```bash
+    curl -fsSL https://pixi.sh/install.sh | sh
+    ```
+
+3. Clone this repo:
+
+    ```bash
+    git clone https://github.com/modular/max-recipes.git
+    ```
+
+4. Navigate to these examples:
+
+    ```bash
+    cd mojo-operation-template
+    ```
 
 ## Running tests ##
 
@@ -42,13 +52,13 @@ inside of a Python MAX graph.
 To run the Mojo unit tests, use
 
 ```sh
-magic run test
+pixi run test
 ```
 
 To run the `pytest` unit tests, use
 
 ```sh
-magic run pytest
+pixi run pytest
 ```
 
 ## Benchmarking ##
@@ -58,7 +68,7 @@ have been configured using the Mojo `benchmark` module. To run them, use the
 command
 
 ```sh
-magic run benchmarks
+pixi run benchmarks
 ```
 
 ## Running a graph containing this operation ##
@@ -67,7 +77,7 @@ A very basic one-operation graph in Python that contains the custom Mojo
 operation can be run using
 
 ```sh
-magic run graph
+pixi run graph
 ```
 
 This will compile the Mojo code for the kernel, place it in a graph, compile
@@ -79,7 +89,7 @@ be used in a larger AI model within the MAX framework.
 Run the command:
 
 ```sh
-magic run profile_amd test_correctness.mojo
+pixi run profile_amd test_correctness.mojo
 ```
 
 This will generate a `test_correctness.log` file containing profile information.
@@ -91,7 +101,7 @@ Check the script inside [profile_amd.sh](./profile_amd.sh) to see how it works.
 To build a binary from a Mojo file and start the debugger run:
 
 ```sh
-magic run debug_amd test_correctness.mojo
+pixi run debug_amd test_correctness.mojo
 ```
 
 You can now set a breakpoint inside the kernel code (press y on the "Make

--- a/mojo-operation-template/benchmarks.mojo
+++ b/mojo-operation-template/benchmarks.mojo
@@ -15,7 +15,6 @@ from benchmark import ThroughputMeasure, BenchId, BenchMetric, Bench, Bencher
 from buffer.dimlist import DimList
 from gpu.host import DeviceContext, DeviceBuffer
 from math import iota
-from max.driver import cpu
 from max.tensor import (
     ManagedTensorSlice,
     InputTensor,
@@ -37,16 +36,17 @@ from utils import IndexList
 # Note: change this to the ID of the GPU you will use.
 alias DEVICE_ID = 0
 
+
 # Wrap a ManagedTensorSlice with a DeviceBuffer which has a lifetime to use
 # Mojo's memory management, and sidestep the Python initialized garbage
 # collected version.
-@value
+@fieldwise_init
 struct _BenchTensor[
     dtype: DType,
     rank: Int, //,
     io_spec: IOSpec,
     static_spec: StaticTensorSpec[dtype, rank],
-]:
+](Copyable, Movable):
     alias tensor_type = ManagedTensorSlice[
         io_spec=io_spec, static_spec=static_spec
     ]

--- a/mojo-operation-template/debug_amd.sh
+++ b/mojo-operation-template/debug_amd.sh
@@ -2,7 +2,7 @@
 
 # Check if a file path was provided
 if [ $# -ne 1 ]; then
-    echo "Usage: magic run debug_amd file_path.mojo"
+    echo "Usage: pixi run debug_amd file_path.mojo"
     exit 1
 fi
 

--- a/mojo-operation-template/graph.py
+++ b/mojo-operation-template/graph.py
@@ -70,6 +70,7 @@ def matrix_multiplication(
                 )
             ],
             parameters={"algorithm": algorithm},
+            device=DeviceRef.from_device(device),
         )[0].tensor
         graph.output(output)
 

--- a/mojo-operation-template/metadata.yaml
+++ b/mojo-operation-template/metadata.yaml
@@ -12,7 +12,7 @@ tags:
   - gpu-programming
 
 tasks:
-  - magic run graph
-  - magic run benchmarks
-  - magic run test
-  - magic run pytest
+  - pixi run graph
+  - pixi run benchmarks
+  - pixi run test
+  - pixi run pytest

--- a/mojo-operation-template/operations/matrix_multiplication.mojo
+++ b/mojo-operation-template/operations/matrix_multiplication.mojo
@@ -32,9 +32,9 @@ from sys.info import simdwidthof
 
 
 fn naive_matrix_multiplication_cpu(
-    out: ManagedTensorSlice,
-    a: ManagedTensorSlice[type = out.type, rank = out.rank],
-    b: ManagedTensorSlice[type = out.type, rank = out.rank],
+    output: ManagedTensorSlice,
+    a: ManagedTensorSlice[dtype = output.dtype, rank = output.rank],
+    b: ManagedTensorSlice[dtype = output.dtype, rank = output.rank],
 ):
     """A naive matrix multiplication used as a fallback on CPU hardware."""
     var M = a.shape()[0]
@@ -44,7 +44,7 @@ fn naive_matrix_multiplication_cpu(
     for row in range(M):
         for col in range(N):
             for k in range(K):
-                out[row, col] = out[row, col] + a[row, k] * b[k, col]
+                output[row, col] = output[row, col] + a[row, k] * b[k, col]
 
 
 # ===-----------------------------------------------------------------------===#

--- a/mojo-operation-template/pyproject.toml
+++ b/mojo-operation-template/pyproject.toml
@@ -34,7 +34,7 @@ pytest = "pytest"
 pytest = ">=8.3.2, <9"
 
 [tool.pixi.dependencies]
-max = "==25.3.0.dev2025042905"
+max = "==25.5.0.dev2025062205"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/mojo-operation-template/tests/common.py
+++ b/mojo-operation-template/tests/common.py
@@ -70,6 +70,7 @@ def matrix_multiplication(
                 )
             ],
             parameters={"algorithm": algorithm},
+            device=DeviceRef.from_device(device),
         )[0].tensor
         graph.output(output)
 


### PR DESCRIPTION
Since the last hackathon, we've moved from Magic to Pixi and made some updates to the syntax of graph operations and Mojo. This updates for all of those changes, and moves the pinned version of MAX to today's nightly release.

I've tested all but the AMD targets locally.