### PR TITLE
Migrate max-serve-multimodal-structured-output from Magic to Pixi

### DIFF
--- a/max-serve-multimodal-structured-output/.gitignore
+++ b/max-serve-multimodal-structured-output/.gitignore
@@ -1,6 +1,5 @@
 
-# pixi environments
+# Pixi environments
 .pixi
 *.egg-info
-# magic environments
-.magic
+pixi.lock

--- a/max-serve-multimodal-structured-output/README.md
+++ b/max-serve-multimodal-structured-output/README.md
@@ -16,7 +16,7 @@ Let's get started.
 
 ## Requirements
 
-Please make sure your system meets our [system requirements](https://docs.modular.com/max/get-started).
+Please make sure your system meets our [system requirements](https://docs.modular.com/max/faq/#system-requirements).
 
 To proceed, ensure you have the `pixi` CLI installed:
 

--- a/max-serve-multimodal-structured-output/README.md
+++ b/max-serve-multimodal-structured-output/README.md
@@ -1,16 +1,16 @@
-# Image to JSON: Multimodal Structured Output with Llama 3.2 Vision, MAX Serve and Pydantic
+# Image to JSON: Multimodal Structured Output with Llama 3.2 Vision, MAX and Pydantic
 
 In this recipe, we will cover:
 
-* How to run a multimodal vision model using Llama 3.2 Vision and MAX Serve
+* How to run a multimodal vision model using Llama 3.2 Vision and MAX
 * Implementing structured output parsing with Pydantic models
 * Converting image analysis into strongly-typed JSON
 
 We'll walk through building a solution that showcases:
 
-* MAX Serve capabilities with multimodal models
+* MAX capabilities with multimodal models
 * Structured output parsing with type safety
-* Simple deployment using magic CLI
+* Simple deployment using pixi CLI
 
 Let's get started.
 
@@ -18,22 +18,16 @@ Let's get started.
 
 Please make sure your system meets our [system requirements](https://docs.modular.com/max/get-started).
 
-To proceed, ensure you have the `magic` CLI installed with the `magic --version` to be **0.7.2** or newer:
+To proceed, ensure you have the `pixi` CLI installed:
 
 ```bash
-curl -ssL https://magic.modular.com/ | bash
+curl -fsSL https://pixi.sh/install.sh | sh
 ```
 
-or update it via:
+...and updated to the latest version:
 
 ```bash
-magic self-update
-```
-
-Then install `max-pipelines` via:
-
-```bash
-magic global install -u max-pipelines
+pixi self-update
 ```
 
 For this recipe, you will need:
@@ -49,7 +43,7 @@ export HUGGING_FACE_HUB_TOKEN=<your-token-yere>
 
 ### GPU requirements
 
-**Structured output with MAX Serve requires GPU access**. For running the app on GPU, ensure your system meets these GPU requirements:
+**Structured output with MAX requires GPU access**. For running the app on GPU, ensure your system meets these GPU requirements:
 
 * Supported GPUs: NVIDIA H100 / H200, A100, A10G, L4, or L40
 * NVIDIA Drivers: [Installation guide here](https://www.nvidia.com/download/index.aspx)
@@ -57,11 +51,11 @@ export HUGGING_FACE_HUB_TOKEN=<your-token-yere>
 
 ## Quick start
 
-1. Download the code for this recipe using the `magic` CLI:
+1. Download the code for this recipe:
 
     ```bash
-    magic init max-serve-multimodal-structured-output --from modular/max-recipes/max-serve-multimodal-structured-output
-    cd max-serve-multimodal-structured-output
+    git clone https://github.com/modularml/max-recipes.git
+    cd max-recipes/max-serve-multimodal-structured-output
     ```
 
 2. Run the server with vision model:
@@ -69,15 +63,15 @@ export HUGGING_FACE_HUB_TOKEN=<your-token-yere>
     **Make sure the port `8010` is available. You can adjust the port settings in [pyproject.toml](./pyproject.toml).**
 
     ```bash
-    magic run server
+    pixi run server
     ```
 
-    This will start MAX Serve with Llama 3.2 Vision and
+    This will start MAX with Llama 3.2 Vision and
 
 3. Run the example code that extracts player information from a basketball image via:
 
     ```bash
-    magic run python main.py
+    pixi run main
     ```
 
     <img src="image.jpg" alt="Players" width="100%" style="max-width: 1024px;">
@@ -132,7 +126,7 @@ How it works:
 
 ### Vision model integration
 
-The application uses the OpenAI client to communicate with MAX Serve:
+The application uses the OpenAI client to communicate with MAX:
 
 ```python
 from openai import OpenAI
@@ -164,11 +158,11 @@ Key components:
 
 * **Multimodal input**: Combines text instructions with image data
 * **Structured parsing**: Uses the Players model to format the response
-* **Inference**: Runs on MAX Serve with OpenAI-compatible API
+* **Inference**: Runs on MAX with OpenAI-compatible API
 
-### MAX Serve Options
+### MAX Options
 
-To enable structured output in MAX Serve, simply include `--enable-structured-output`.
+To enable structured output in MAX, simply include `--enable-structured-output`.
 
 To see other options, make sure to check out the help:
 
@@ -178,18 +172,18 @@ max serve --help
 
 ## Conclusion
 
-In this recipe, we've built a system for extracting structured data from images using Llama 3.2 Vision and MAX Serve. We've explored:
+In this recipe, we've built a system for extracting structured data from images using Llama 3.2 Vision and MAX. We've explored:
 
-* **Basic setup**: Using MAX Serve with GPU support
+* **Basic setup**: Using MAX with GPU support
 * **Structured output**: Implementing type-safe data extraction with Pydantic
 * **Multimodal processing**: Handling both image and text inputs
-* **Local deployment**: Running the model with MAX Serve
+* **Local deployment**: Running the model with MAX
 
 This implementation provides a foundation for building more complex vision-based applications with structured output.
 
 ## Next steps
 
-* Deploy Llama 3.2 Vision on GPU with MAX Serve to [AWS, GCP or Azure](https://docs.modular.com/max/tutorials/max-serve-local-to-cloud/) or on [Kubernetes](https://docs.modular.com/max/tutorials/deploy-max-serve-on-kubernetes/)
+* Deploy Llama 3.2 Vision on GPU with MAX to [AWS, GCP or Azure](https://docs.modular.com/max/tutorials/max-serve-local-to-cloud/) or on [Kubernetes](https://docs.modular.com/max/tutorials/deploy-max-serve-on-kubernetes/)
 * Explore MAX's [documentation](https://docs.modular.com/max/) for additional features
 * Join our [Modular Forum](https://forum.modular.com/) and [Discord community](https://discord.gg/modular) to share your experiences and get support
 

--- a/max-serve-multimodal-structured-output/metadata.yaml
+++ b/max-serve-multimodal-structured-output/metadata.yaml
@@ -1,6 +1,6 @@
 version: 1.0
-long_title: "Image to JSON: Multimodal Structured Output with Llama 3.2 Vision, MAX Serve and Pydantic"
-short_title: "MAX Serve Multi-Modal Structured Output"
+long_title: "Image to JSON: Multimodal Structured Output with Llama 3.2 Vision, MAX and Pydantic"
+short_title: "MAX Multi-Modal Structured Output"
 author: "Ehsan M. Kermani"
 author_image: "author/ehsan.jpg"
 author_url: "https://www.linkedin.com/in/ehsanmkermani/"
@@ -14,5 +14,5 @@ tags:
   - llama3-vision
 
 tasks:
-  - magic run server
-  - magic run main
+  - pixi run server
+  - pixi run main

--- a/max-serve-multimodal-structured-output/pyproject.toml
+++ b/max-serve-multimodal-structured-output/pyproject.toml
@@ -16,7 +16,7 @@ requires = ["hatchling"]
 packages = ["."]
 
 [tool.pixi.project]
-channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
+channels = ["https://conda.modular.com/max-nightly", "conda-forge"]
 platforms = ["linux-64", "linux-aarch64"]
 
 [tool.pixi.pypi-dependencies]
@@ -28,4 +28,5 @@ main = "python main.py"
 tests = "echo 'test passed'"
 
 [tool.pixi.dependencies]
+modular = ">=25.5.0.dev2025070905,<26"
 honcho = ">=2.0.0,<3"


### PR DESCRIPTION
## Summary
- Migrated the multimodal structured output recipe from Magic to Pixi package manager
- Replaced global max-pipelines installation with modular package dependency
- Updated all references from "MAX Serve" to "MAX" for consistency

## Changes
- **.gitignore**: Updated from "magic environments" to "Pixi environments", added pixi.lock
- **README.md**:
  - Replaced Magic installation instructions with Pixi
  - Removed `magic global install -u max-pipelines` command
  - Changed all `magic run` commands to `pixi run`
  - Updated from `magic init` to `git clone` for recipe download
  - Renamed "MAX Serve" to "MAX" throughout
- **pyproject.toml**:
  - Added `modular = ">=25.5.0.dev2025070905,<26"` dependency to replace max-pipelines
  - Reordered channels to prioritize max-nightly channel
- **metadata.yaml**:
  - Updated tasks from `magic run` to `pixi run`
  - Updated titles from "MAX Serve" to "MAX"

## Test plan
- [ ] Verify Pixi installation works as documented
- [ ] Test that `pixi run server` starts the Llama 3.2 Vision model correctly
- [ ] Confirm `pixi run main` processes the basketball image and extracts player data
- [ ] Verify structured output parsing works with Pydantic models
- [ ] Test that all dependencies are properly resolved

🤖 Generated with [Claude Code](https://claude.ai/code)