### PR TITLE
Migrate ai-weather-agent recipe from Magic to Pixi

### DIFF
--- a/ai-weather-agent/.gitignore
+++ b/ai-weather-agent/.gitignore
@@ -1,6 +1,5 @@
-# pixi environments
+# Pixi environments
 .pixi
 *.egg-info
-# magic environments
-.magic
+pixi.lock
 max

--- a/ai-weather-agent/Procfile
+++ b/ai-weather-agent/Procfile
@@ -1,4 +1,4 @@
 max-serve-llm: MAX_SERVE_PORT=8010 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max serve --model-path modularai/Llama-3.1-8B-Instruct-GGUF --max-length 2048
 max-serve-embedding: MAX_SERVE_PORT=7999 HUGGING_FACE_HUB_TOKEN=$(cat backend/.env | grep HUGGING_FACE_HUB_TOKEN | cut -d '=' -f2) max serve --model-path sentence-transformers/all-mpnet-base-v2
-backend: cd backend && magic run backend
-frontend: cd frontend && magic run frontend
+backend: cd backend && pixi run backend
+frontend: cd frontend && pixi run frontend

--- a/ai-weather-agent/Procfile.clean
+++ b/ai-weather-agent/Procfile.clean
@@ -1,3 +1,3 @@
-cleanup: pkill -f "max serve" || true && pkill -f "magic run backend" || true && pkill -f "magic run frontend" || true
+cleanup: pkill -f "max serve" || true && pkill -f "pixi run backend" || true && pkill -f "pixi run frontend" || true
 gpu-cleanup: command -v nvidia-smi >/dev/null && nvidia-smi pmon -c 1 | grep python | awk '{print $2}' | xargs -r kill -9 2>/dev/null || true
 port-cleanup: lsof -ti:7999,8001,8010,3000 | xargs -r kill -9 2>/dev/null || true

--- a/ai-weather-agent/Procfile.demo
+++ b/ai-weather-agent/Procfile.demo
@@ -1,2 +1,2 @@
-backend: cd backend && magic run backend
-frontend: cd frontend && magic run frontend
+backend: cd backend && pixi run backend
+frontend: cd frontend && pixi run frontend

--- a/ai-weather-agent/README.md
+++ b/ai-weather-agent/README.md
@@ -1,4 +1,4 @@
-# Agentic Workflows: Build your own Weather Agent with MAX Serve, FastAPI and NextJS
+# Agentic Workflows: Build your own Weather Agent with MAX, FastAPI and NextJS
 
 This recipe demonstrates how to build an intelligent weather assistant that combines:
 
@@ -39,24 +39,12 @@ You'll learn how to:
 
 ## Requirements
 
-Please make sure your system meets our [system requirements](https://docs.modular.com/max/get-started).
+Please make sure your system meets our [system requirements](https://docs.modular.com/max/faq/#system-requirements).
 
-To proceed, ensure you have the `magic` CLI installed with the `magic --version` to be **0.7.2** or newer:
-
-```bash
-curl -ssL https://magic.modular.com/ | bash
-```
-
-or update it via:
+To proceed, ensure you have the `pixi` CLI installed. You can install it via:
 
 ```bash
-magic self-update
-```
-
-Then install `max-pipelines` via:
-
-```bash
-magic global install -u max-pipelines
+curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
 For this recipe, you will also need:
@@ -74,11 +62,11 @@ echo "WEATHERAPI_API_KEY=your_api_key" >> backend/.env
 
 ## Quick start
 
-1. Download the code for this recipe using `magic` CLI:
+1. Download the code for this recipe:
 
     ```bash
-    magic init ai-weather-agent --from modular/max-recipes/ai-weather-agent
-    cd ai-weather-agent
+    git clone https://github.com/modular/max-recipes.git
+    cd max-recipes/ai-weather-agent
     ```
 
 2. Run the application:
@@ -86,15 +74,15 @@ echo "WEATHERAPI_API_KEY=your_api_key" >> backend/.env
     **Make sure the ports `7999, 8001` and `8010` are available. You can adjust the port settings in [Procfile](./Procfile).**
 
     ```bash
-    magic run app
+    pixi run app
     ```
 
     Note that it may take a few minutes for models to be downloaded and compiled.
 
 3. Open [http://localhost:3000](http://localhost:3000) in your browser to see the UI when **all services** below are ready:
 
-   * MAX Serve embedding on port `7999`
-   * MAX Serve Llama 3 on port `8000` and
+   * MAX embedding on port `7999`
+   * MAX Llama 3 on port `8000` and
    * Backend FastAPI on port `8001`
 
     <img src="ui.png" alt="Chat interface" width="100%" style="max-width: 800px;">
@@ -112,7 +100,7 @@ echo "WEATHERAPI_API_KEY=your_api_key" >> backend/.env
 4. And once done with the app, to clean up the resources run:
 
     ```bash
-    magic run clean
+    pixi run clean
     ```
 
 ## System architecture
@@ -125,12 +113,12 @@ The architecture consists of several key components:
 
 * **Frontend (Next.js)**: A modern React application providing real-time chat interface and weather visualization
 * **Backend (FastAPI)**: Orchestrates the entire flow, handling request routing and response generation
-* **MAX Serve**: Runs the Llama 3 model for intent detection, function calling, and response generation
+* **MAX**: Runs the Llama 3 model for intent detection, function calling, and response generation
 * **WeatherAPI**: External service providing current weather conditions and forecasts
 * **Sentence Transformers**: Used `sentence-transformers/all-mpnet-base-v2` for generating embeddings for semantic caching
 * **Semantic Cache**: Stores recent query results to improve response times
 
-Each component is designed to be independently scalable and maintainable. The backend uses FastAPI's async capabilities to handle concurrent requests efficiently, while MAX Serve provides high-performance inference for the LLM components.
+Each component is designed to be independently scalable and maintainable. The backend uses FastAPI's async capabilities to handle concurrent requests efficiently, while MAX provides high-performance inference for the LLM components.
 
 ## Request flow
 
@@ -404,7 +392,7 @@ class SemanticCache:
         self._lock = Lock()
 
     async def _compute_embedding(self, text: str) -> np.ndarray:
-        """Get embeddings from MAX Serve embedding endpoint"""
+        """Get embeddings from MAX embedding endpoint"""
         response = await embedding_client.embeddings.create(
             model=EMBEDDING_MODEL,
             input=text
@@ -597,7 +585,7 @@ const operationLabels: Record<string, string> = {
 Common issues and solutions:
 
 1. **LLM server connection issues**
-   * Ensure MAX Serve is running (`magic run app`)
+   * Ensure MAX is running (`pixi run app`)
    * Check logs for any GPU-related errors
    * Verify Hugging Face token is set correctly
 
@@ -670,7 +658,7 @@ The patterns and components shown here provide a solid foundation for building y
 Now that you've built a foundation for AI-powered applications, you can explore more advanced deployments and features:
 
 * Explore [MAX documentation](https://docs.modular.com/max/) for more features
-* Deploy MAX Serve on [AWS, GCP or Azure](https://docs.modular.com/max/tutorials/max-serve-local-to-cloud/)
+* Deploy MAX on [AWS, GCP or Azure](https://docs.modular.com/max/tutorials/max-serve-local-to-cloud/)
 * Join our [Modular Forum](https://forum.modular.com/) and [Discord community](https://discord.gg/modular)
 
 We're excited to see what you'll build with MAX! Share your projects with us using `#ModularAI` on social media.

--- a/ai-weather-agent/backend/pyproject.toml
+++ b/ai-weather-agent/backend/pyproject.toml
@@ -27,10 +27,13 @@ packages = ["src"]
 
 [tool.pixi.project]
 channels = [
-    "conda-forge",
     "https://conda.modular.com/max-nightly",
+    "conda-forge",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
+
+[tool.pixi.dependencies]
+modular = ">=25.5.0.dev2025070905,<26"
 
 [tool.pixi.pypi-dependencies]
 backend = { path = ".", editable = true }

--- a/ai-weather-agent/metadata.yaml
+++ b/ai-weather-agent/metadata.yaml
@@ -1,5 +1,5 @@
 version: 1.0
-long_title: "Agentic Workflows: Build your own Weather Agent with MAX Serve, FastAPI and NextJS"
+long_title: "Agentic Workflows: Build your own Weather Agent with MAX, FastAPI and NextJS"
 short_title: "Build your own AI Weather Agent"
 author: "Ehsan M. Kermani"
 author_image: "author/ehsan.jpg"
@@ -15,5 +15,5 @@ tags:
   - observability
 
 tasks:
-  - magic run app
-  - magic run clean
+  - pixi run app
+  - pixi run clean

--- a/ai-weather-agent/pixi.toml
+++ b/ai-weather-agent/pixi.toml
@@ -1,8 +1,8 @@
 [project]
 authors = ["Modular <hello@modular.com>"]
 channels = [
-    "conda-forge",
     "https://conda.modular.com/max-nightly",
+    "conda-forge",
 ]
 description = "Add a short description here"
 name = "frontend"
@@ -19,3 +19,4 @@ demo = "honcho -f Procfile.demo start"
 docker-compose = ">=2.29"
 bash = ">=5.2.21,<6"
 honcho = ">=2.0.0,<3"
+modular = ">=25.5.0.dev2025070905,<26"


### PR DESCRIPTION
## Summary
- Migrated ai-weather-agent recipe from Magic CLI to Pixi package manager
- Updated all Magic references to use Pixi commands
- Changed "MAX Serve" references to "MAX" throughout documentation  
- Added modular package dependency to replace global max-pipelines installation
- Updated system requirements link to point to FAQ page

## Test plan
- [ ] Verify pixi run app launches all services correctly
- [ ] Test weather queries work end-to-end
- [ ] Confirm semantic caching and performance monitoring still function
- [ ] Validate clean shutdown with pixi run clean

🤖 Generated with [Claude Code](https://claude.ai/code)