### PR TITLE
Align mojo-operation-template with Pixi migration pattern

### DIFF
--- a/mojo-operation-template/.gitignore
+++ b/mojo-operation-template/.gitignore
@@ -1,9 +1,7 @@
-# pixi environments
+# Pixi environments
 .pixi
 pixi.lock
 *.egg-info
-# magic environments
-.magic
 .env
 .venv
 # build products

--- a/mojo-operation-template/pyproject.toml
+++ b/mojo-operation-template/pyproject.toml
@@ -14,8 +14,8 @@ packages = ["."]
 
 [tool.pixi.project]
 channels = [
-    "conda-forge",
     "https://conda.modular.com/max-nightly",
+    "conda-forge",
 ]
 platforms = ["linux-64", "osx-arm64", "linux-aarch64"]
 
@@ -34,7 +34,7 @@ pytest = "pytest"
 pytest = ">=8.3.2, <9"
 
 [tool.pixi.dependencies]
-max = "==25.5.0.dev2025062205"
+max = ">=25.5.0.dev2025070905,<26"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }


### PR DESCRIPTION
Minor alignment updates to ensure consistency with other migrated recipes. The template was already properly configured for Pixi, requiring only small adjustments to .gitignore, MAX dependency versioning, and channel ordering.

🤖 Generated with [Claude Code](https://claude.ai/code)